### PR TITLE
export: adapt retries for VM limits

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.7"
+          go-version: "1.25.9"
 
       - name: Run govulncheck
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ All notable changes to vmgather are documented here. The format follows [Keep a 
 - `query_range` failures caused by VictoriaMetrics execution timeout no longer fail the whole export immediately; vmgather now retries by splitting the current time window down to a configured minimum.
 - If minimum-window `query_range` retries still hit VictoriaMetrics execution timeout, autopilot now retries with the next sampling step up to 5 minutes before returning the final error.
 - `/api/v1/export` failures caused by excessive matched series no longer fail immediately when multiple jobs are selected; vmgather now retries sequentially per job.
+- Split-by-job and split-by-time retries now keep successful sub-attempt output in a temporary group file until the whole split succeeds, preventing duplicate metrics after a later sub-attempt fails.
 - Context deadline errors are now classified as query timeouts in the adaptive exporter path, so timeout-driven retries keep working under request deadlines.
+- Export safety defaults now also recover from invalid negative split settings, and the JSON contract no longer marks the non-pointer `safety` field as `omitempty`.
 
 ## [v1.9.1] - 2026-02-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ All notable changes to vmgather are documented here. The format follows [Keep a 
 - Context deadline errors are now classified as query timeouts in the adaptive exporter path, so timeout-driven retries keep working under request deadlines.
 - Export safety defaults now also recover from invalid negative split settings, and the JSON contract no longer marks the non-pointer `safety` field as `omitempty`.
 
+### Security
+- Docker and security-scan Go toolchains are upgraded to Go `1.25.9` to consume the latest Go standard library vulnerability fixes.
+- Docker runtime images now use a refreshed pinned distroless `base-debian12:nonroot` digest with fixed OpenSSL packages.
+
 ## [v1.9.1] - 2026-02-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to vmgather are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and versions adhere to semantic versioning.
 
+## [v1.10.0] - 2026-04-28
+
+### Added
+- Export jobs now track adaptive retry progress (`adaptive_retries`, `last_error_kind`, `current_strategy`) so the UI can show when vmgather is automatically changing strategy instead of just failing the batch.
+- Added explicit VictoriaMetrics API error classification for missing export route, query timeouts, too-many-series failures, and transient transport errors.
+- Added focused coverage for adaptive export behavior, including time-splitting retries, job-based splitting, failed partial-attempt cleanup, and progress reporting.
+
+### Changed
+- Export pipeline now writes each batch attempt into a temporary attempt file and appends it to the main staging file only after the full attempt succeeds, preventing corrupted or duplicated staging output after retries.
+- Custom selector exports with selected jobs now prefer `/api/v1/export` when the selector can be safely rewritten with a `job=~...` matcher, avoiding unnecessary `query_range` fallback.
+- Export requests now send `reduce_mem_usage=1` and `max_rows_per_line=10000` to VictoriaMetrics `/api/v1/export` for safer large-bundle collection.
+- Export progress UI now sends adaptive safety settings by default and surfaces automatic retry strategy changes during long-running exports.
+
+### Fixed
+- `query_range` failures caused by VictoriaMetrics execution timeout no longer fail the whole export immediately; vmgather now retries by splitting the current time window down to a configured minimum.
+- `/api/v1/export` failures caused by excessive matched series no longer fail immediately when multiple jobs are selected; vmgather now retries sequentially per job.
+- Context deadline errors are now classified as query timeouts in the adaptive exporter path, so timeout-driven retries keep working under request deadlines.
+
 ## [v1.9.1] - 2026-02-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,22 @@ All notable changes to vmgather are documented here. The format follows [Keep a 
 ## [v1.10.0] - 2026-04-28
 
 ### Added
+- Added default export autopilot mode for `query_range` exports. It starts with the highest supported sampling fidelity and only increases the sampling step after VictoriaMetrics still rejects the already-split minimum time windows.
+- Added a hard autopilot sampling ceiling of 5 minutes; vmgather now stops there with an actionable error instead of silently creating lower-fidelity bundles.
+- Archive metadata now records adaptive mode, sampled export step, max step, and adaptive retry decisions so support can see whether a bundle stayed exact or was sampled by autopilot.
 - Export jobs now track adaptive retry progress (`adaptive_retries`, `last_error_kind`, `current_strategy`) so the UI can show when vmgather is automatically changing strategy instead of just failing the batch.
 - Added explicit VictoriaMetrics API error classification for missing export route, query timeouts, too-many-series failures, and transient transport errors.
-- Added focused coverage for adaptive export behavior, including time-splitting retries, job-based splitting, failed partial-attempt cleanup, and progress reporting.
+- Added focused coverage for adaptive export behavior, including autopilot step increases, the 5-minute stop condition, time-splitting retries, job-based splitting, failed partial-attempt cleanup, and progress reporting.
 
 ### Changed
 - Export pipeline now writes each batch attempt into a temporary attempt file and appends it to the main staging file only after the full attempt succeeds, preventing corrupted or duplicated staging output after retries.
 - Custom selector exports with selected jobs now prefer `/api/v1/export` when the selector can be safely rewritten with a `job=~...` matcher, avoiding unnecessary `query_range` fallback.
 - Export requests now send `reduce_mem_usage=1` and `max_rows_per_line=10000` to VictoriaMetrics `/api/v1/export` for safer large-bundle collection.
-- Export progress UI now sends adaptive safety settings by default and surfaces automatic retry strategy changes during long-running exports.
+- Export progress UI now enables adaptive autopilot by default, exposes a single toggle, and surfaces automatic retry strategy changes during long-running exports.
 
 ### Fixed
 - `query_range` failures caused by VictoriaMetrics execution timeout no longer fail the whole export immediately; vmgather now retries by splitting the current time window down to a configured minimum.
+- If minimum-window `query_range` retries still hit VictoriaMetrics execution timeout, autopilot now retries with the next sampling step up to 5 minutes before returning the final error.
 - `/api/v1/export` failures caused by excessive matched series no longer fail immediately when multiple jobs are selected; vmgather now retries sequentially per job.
 - Context deadline errors are now classified as query timeouts in the adaptive exporter path, so timeout-driven retries keep working under request deadlines.
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PKG_TAG ?= $(shell git describe --tags --abbrev=0 2>/dev/null || echo "latest")
 PLATFORMS ?= linux/amd64,linux/arm64,linux/arm
 
 # Go version for build
-GO_VERSION ?= 1.25.7
+GO_VERSION ?= 1.25.9
 GOVULNCHECK_VERSION ?= v1.1.4
 DOCKER_OUTPUT ?= type=docker
 DOCKER_COMPOSE := $(shell docker compose version >/dev/null 2>&1 && echo "docker compose" || echo "docker-compose")
@@ -813,7 +813,7 @@ security-check-go:
 	@echo "================================================================================"
 	@echo "Security Check: govulncheck"
 	@echo "================================================================================"
-	@docker run --rm -v "$$PWD:/work" -w /work golang:$(GO_VERSION)-alpine@sha256:f6751d823c26342f9506c03797d2527668d095b0a15f1862cddb4d927a7a4ced sh -ec '\
+	@docker run --rm -v "$$PWD:/work" -w /work golang:$(GO_VERSION)-alpine@sha256:5caaf1cca9dc351e13deafbc3879fd4754801acba8653fa9540cea125d01a71f sh -ec '\
 		go install golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION); \
 		$$(go env GOPATH)/bin/govulncheck ./...'
 

--- a/build/docker/Dockerfile.vmgather
+++ b/build/docker/Dockerfile.vmgather
@@ -1,12 +1,12 @@
 # syntax=docker/dockerfile:1
-ARG GO_VERSION=1.25.7
-FROM golang:${GO_VERSION}-alpine@sha256:f6751d823c26342f9506c03797d2527668d095b0a15f1862cddb4d927a7a4ced AS builder
+ARG GO_VERSION=1.25.9
+FROM golang:${GO_VERSION}-alpine@sha256:5caaf1cca9dc351e13deafbc3879fd4754801acba8653fa9540cea125d01a71f AS builder
 WORKDIR /src
 COPY . .
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w" -o /out/vmgather ./cmd/vmgather && \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w" -o /out/container-healthcheck ./cmd/container-healthcheck
 
-FROM gcr.io/distroless/base-debian12:nonroot@sha256:107333192f6732e786f65df4df77f1d8bfb500289aad09540e43e0f7b6a2b816
+FROM gcr.io/distroless/base-debian12:nonroot@sha256:956eee19d77039968b05209dce21e43c84fb2bae7644a2b0546b36996c96e305
 WORKDIR /tmp
 COPY --from=builder /out/vmgather /usr/local/bin/vmgather
 COPY --from=builder /out/container-healthcheck /usr/local/bin/container-healthcheck

--- a/build/docker/Dockerfile.vmimporter
+++ b/build/docker/Dockerfile.vmimporter
@@ -1,12 +1,12 @@
 # syntax=docker/dockerfile:1
-ARG GO_VERSION=1.25.7
-FROM golang:${GO_VERSION}-alpine@sha256:f6751d823c26342f9506c03797d2527668d095b0a15f1862cddb4d927a7a4ced AS builder
+ARG GO_VERSION=1.25.9
+FROM golang:${GO_VERSION}-alpine@sha256:5caaf1cca9dc351e13deafbc3879fd4754801acba8653fa9540cea125d01a71f AS builder
 WORKDIR /src
 COPY . .
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w" -o /out/vmimporter ./cmd/vmimporter && \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w" -o /out/container-healthcheck ./cmd/container-healthcheck
 
-FROM gcr.io/distroless/base-debian12:nonroot@sha256:107333192f6732e786f65df4df77f1d8bfb500289aad09540e43e0f7b6a2b816
+FROM gcr.io/distroless/base-debian12:nonroot@sha256:956eee19d77039968b05209dce21e43c84fb2bae7644a2b0546b36996c96e305
 WORKDIR /tmp
 COPY --from=builder /out/vmimporter /usr/local/bin/vmimporter
 COPY --from=builder /out/container-healthcheck /usr/local/bin/container-healthcheck

--- a/internal/application/services/export_defaults.go
+++ b/internal/application/services/export_defaults.go
@@ -30,7 +30,7 @@ func ApplyExportDefaults(config *domain.ExportConfig) {
 	if safety.Mode == "" {
 		safety.Mode = domain.ExportAdaptivityAutopilot
 	}
-	if safety.Mode != domain.ExportAdaptivityOff && !safety.AutoSplit && !safety.SplitByJob && !safety.SplitByMetricName && safety.MinWindowSeconds == 0 && safety.MaxSplitDepth == 0 {
+	if safety.Mode != domain.ExportAdaptivityOff && !safety.AutoSplit && !safety.SplitByJob && !safety.SplitByMetricName && safety.MinWindowSeconds <= 0 && safety.MaxSplitDepth <= 0 {
 		safety.AutoSplit = true
 		safety.SplitByJob = true
 	}

--- a/internal/application/services/export_defaults.go
+++ b/internal/application/services/export_defaults.go
@@ -2,6 +2,10 @@ package services
 
 import "github.com/VictoriaMetrics/vmgather/internal/domain"
 
+const MaxAutopilotMetricStepSeconds = 5 * 60
+
+var defaultAutopilotStepLadderSeconds = []int{30, 60, 120, MaxAutopilotMetricStepSeconds}
+
 // ApplyExportDefaults normalizes export configuration for CLI and server usage.
 func ApplyExportDefaults(config *domain.ExportConfig) {
 	settings := &config.Batching
@@ -23,12 +27,17 @@ func ApplyExportDefaults(config *domain.ExportConfig) {
 	if settings.CustomIntervalSecs > maxSeconds {
 		settings.CustomIntervalSecs = maxSeconds
 	}
-	if config.MetricStepSeconds <= 0 {
-		config.MetricStepSeconds = RecommendedMetricStepSeconds(config.TimeRange)
+	if safety.Mode == "" {
+		safety.Mode = domain.ExportAdaptivityAutopilot
 	}
-	if !safety.AutoSplit && !safety.SplitByJob && !safety.SplitByMetricName && safety.MinWindowSeconds == 0 && safety.MaxSplitDepth == 0 {
+	if safety.Mode != domain.ExportAdaptivityOff && !safety.AutoSplit && !safety.SplitByJob && !safety.SplitByMetricName && safety.MinWindowSeconds == 0 && safety.MaxSplitDepth == 0 {
 		safety.AutoSplit = true
 		safety.SplitByJob = true
+	}
+	if safety.Mode == domain.ExportAdaptivityOff {
+		safety.AutoSplit = false
+		safety.SplitByJob = false
+		safety.SplitByMetricName = false
 	}
 	if safety.MinWindowSeconds <= 0 {
 		safety.MinWindowSeconds = 5
@@ -36,7 +45,51 @@ func ApplyExportDefaults(config *domain.ExportConfig) {
 	if safety.MaxSplitDepth <= 0 {
 		safety.MaxSplitDepth = 8
 	}
+	if safety.MaxStepSeconds <= 0 || safety.MaxStepSeconds > MaxAutopilotMetricStepSeconds {
+		safety.MaxStepSeconds = MaxAutopilotMetricStepSeconds
+	}
+	if safety.MaxStepSeconds < MinBatchIntervalSeconds {
+		safety.MaxStepSeconds = MinBatchIntervalSeconds
+	}
+	safety.StepLadderSeconds = normalizeStepLadder(safety.StepLadderSeconds, safety.MaxStepSeconds)
+	if config.MetricStepSeconds <= 0 {
+		if safety.Mode == domain.ExportAdaptivityAutopilot {
+			config.MetricStepSeconds = safety.StepLadderSeconds[0]
+		} else {
+			config.MetricStepSeconds = RecommendedMetricStepSeconds(config.TimeRange)
+		}
+	}
+	if config.MetricStepSeconds > safety.MaxStepSeconds {
+		config.MetricStepSeconds = safety.MaxStepSeconds
+	}
 	if !config.Obfuscation.Enabled {
 		config.Obfuscation = domain.ObfuscationConfig{DropLabels: config.Obfuscation.DropLabels}
 	}
+}
+
+func normalizeStepLadder(values []int, maxStepSeconds int) []int {
+	if len(values) == 0 {
+		values = defaultAutopilotStepLadderSeconds
+	}
+	seen := make(map[int]struct{}, len(values))
+	result := make([]int, 0, len(values))
+	for _, step := range values {
+		if step < MinBatchIntervalSeconds || step > maxStepSeconds {
+			continue
+		}
+		if _, ok := seen[step]; ok {
+			continue
+		}
+		seen[step] = struct{}{}
+		result = append(result, step)
+	}
+	if len(result) == 0 {
+		result = []int{maxStepSeconds}
+	}
+	for i := 1; i < len(result); i++ {
+		for j := i; j > 0 && result[j] < result[j-1]; j-- {
+			result[j], result[j-1] = result[j-1], result[j]
+		}
+	}
+	return result
 }

--- a/internal/application/services/export_defaults.go
+++ b/internal/application/services/export_defaults.go
@@ -5,6 +5,7 @@ import "github.com/VictoriaMetrics/vmgather/internal/domain"
 // ApplyExportDefaults normalizes export configuration for CLI and server usage.
 func ApplyExportDefaults(config *domain.ExportConfig) {
 	settings := &config.Batching
+	safety := &config.Safety
 	if !settings.Enabled && settings.Strategy == "" && settings.CustomIntervalSecs == 0 {
 		settings.Enabled = true
 	}
@@ -24,6 +25,16 @@ func ApplyExportDefaults(config *domain.ExportConfig) {
 	}
 	if config.MetricStepSeconds <= 0 {
 		config.MetricStepSeconds = RecommendedMetricStepSeconds(config.TimeRange)
+	}
+	if !safety.AutoSplit && !safety.SplitByJob && !safety.SplitByMetricName && safety.MinWindowSeconds == 0 && safety.MaxSplitDepth == 0 {
+		safety.AutoSplit = true
+		safety.SplitByJob = true
+	}
+	if safety.MinWindowSeconds <= 0 {
+		safety.MinWindowSeconds = 5
+	}
+	if safety.MaxSplitDepth <= 0 {
+		safety.MaxSplitDepth = 8
 	}
 	if !config.Obfuscation.Enabled {
 		config.Obfuscation = domain.ObfuscationConfig{DropLabels: config.Obfuscation.DropLabels}

--- a/internal/application/services/export_defaults_test.go
+++ b/internal/application/services/export_defaults_test.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -44,5 +46,37 @@ func TestApplyExportDefaults_PreservesDropLabels(t *testing.T) {
 	}
 	if len(cfg.Obfuscation.DropLabels) != 2 {
 		t.Fatalf("expected drop labels to be preserved, got %v", cfg.Obfuscation.DropLabels)
+	}
+}
+
+func TestApplyExportDefaults_EnablesSafetyWithNegativeSplitSettings(t *testing.T) {
+	cfg := domain.ExportConfig{
+		TimeRange: domain.TimeRange{
+			Start: time.Now().Add(-time.Hour),
+			End:   time.Now(),
+		},
+		Safety: domain.ExportSafetyConfig{
+			MinWindowSeconds: -10,
+			MaxSplitDepth:    -1,
+		},
+	}
+
+	ApplyExportDefaults(&cfg)
+
+	if !cfg.Safety.AutoSplit || !cfg.Safety.SplitByJob {
+		t.Fatalf("expected invalid negative split settings to bootstrap safe defaults, got %+v", cfg.Safety)
+	}
+	if cfg.Safety.MinWindowSeconds != 5 || cfg.Safety.MaxSplitDepth != 8 {
+		t.Fatalf("expected negative split settings to be normalized, got %+v", cfg.Safety)
+	}
+}
+
+func TestExportConfigSafetyJSONIsExplicit(t *testing.T) {
+	data, err := json.Marshal(domain.ExportConfig{})
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	if !strings.Contains(string(data), `"safety"`) {
+		t.Fatalf("expected safety field to be explicit in JSON, got %s", string(data))
 	}
 }

--- a/internal/application/services/export_defaults_test.go
+++ b/internal/application/services/export_defaults_test.go
@@ -24,6 +24,15 @@ func TestApplyExportDefaults_PreservesDropLabels(t *testing.T) {
 	if cfg.MetricStepSeconds == 0 {
 		t.Fatalf("expected metric step to be set")
 	}
+	if !cfg.Safety.AutoSplit || !cfg.Safety.SplitByJob {
+		t.Fatalf("expected safety defaults to be enabled, got %+v", cfg.Safety)
+	}
+	if cfg.Safety.MinWindowSeconds != 5 {
+		t.Fatalf("expected min window to default to 5s, got %d", cfg.Safety.MinWindowSeconds)
+	}
+	if cfg.Safety.MaxSplitDepth != 8 {
+		t.Fatalf("expected max split depth to default to 8, got %d", cfg.Safety.MaxSplitDepth)
+	}
 	if len(cfg.Obfuscation.DropLabels) != 2 {
 		t.Fatalf("expected drop labels to be preserved, got %v", cfg.Obfuscation.DropLabels)
 	}

--- a/internal/application/services/export_defaults_test.go
+++ b/internal/application/services/export_defaults_test.go
@@ -24,6 +24,9 @@ func TestApplyExportDefaults_PreservesDropLabels(t *testing.T) {
 	if cfg.MetricStepSeconds == 0 {
 		t.Fatalf("expected metric step to be set")
 	}
+	if cfg.Safety.Mode != domain.ExportAdaptivityAutopilot {
+		t.Fatalf("expected autopilot safety mode, got %q", cfg.Safety.Mode)
+	}
 	if !cfg.Safety.AutoSplit || !cfg.Safety.SplitByJob {
 		t.Fatalf("expected safety defaults to be enabled, got %+v", cfg.Safety)
 	}
@@ -32,6 +35,12 @@ func TestApplyExportDefaults_PreservesDropLabels(t *testing.T) {
 	}
 	if cfg.Safety.MaxSplitDepth != 8 {
 		t.Fatalf("expected max split depth to default to 8, got %d", cfg.Safety.MaxSplitDepth)
+	}
+	if cfg.Safety.MaxStepSeconds != MaxAutopilotMetricStepSeconds {
+		t.Fatalf("expected max step to default to 5m, got %d", cfg.Safety.MaxStepSeconds)
+	}
+	if cfg.MetricStepSeconds != MinBatchIntervalSeconds {
+		t.Fatalf("expected autopilot to start at max precision step, got %d", cfg.MetricStepSeconds)
 	}
 	if len(cfg.Obfuscation.DropLabels) != 2 {
 		t.Fatalf("expected drop labels to be preserved, got %v", cfg.Obfuscation.DropLabels)

--- a/internal/application/services/export_service.go
+++ b/internal/application/services/export_service.go
@@ -337,20 +337,16 @@ func (s *exportServiceImpl) exportWindowAdaptive(
 		}
 		ReportAdaptiveRetry(ctx, progress)
 		recordAdaptiveDecision(stats, progress)
-		total := 0
+		children := make([]exportAttempt, 0, len(attempt.Jobs))
 		for _, job := range attempt.Jobs {
 			child, ok := s.buildJobSplitAttempt(config, attempt, job)
 			if !ok {
 				return 0, enrichAdaptiveError(kind, err, attempt, config.Safety.MinWindowSeconds)
 			}
 			child.Depth = attempt.Depth + 1
-			count, childErr := s.exportWindowAdaptive(ctx, client, config, child, mainStagingFile, obfuscator, retryCount, stats)
-			if childErr != nil {
-				return 0, childErr
-			}
-			total += count
+			children = append(children, child)
 		}
-		return total, nil
+		return s.runSplitAttemptsAtomically(ctx, client, config, children, mainStagingFile, obfuscator, retryCount, stats)
 	case kind == vm.ErrorKindQueryTimeout && attempt.UseQueryRange:
 		if config.Safety.AutoSplit && attempt.Depth < config.Safety.MaxSplitDepth {
 			left, right, ok := splitTimeRange(attempt.TimeRange, config.Safety.MinWindowSeconds)
@@ -374,15 +370,7 @@ func (s *exportServiceImpl) exportWindowAdaptive(
 				rightAttempt.Depth = attempt.Depth + 1
 				rightAttempt.Strategy = "query_range"
 
-				leftCount, leftErr := s.exportWindowAdaptive(ctx, client, config, leftAttempt, mainStagingFile, obfuscator, retryCount, stats)
-				if leftErr != nil {
-					return 0, leftErr
-				}
-				rightCount, rightErr := s.exportWindowAdaptive(ctx, client, config, rightAttempt, mainStagingFile, obfuscator, retryCount, stats)
-				if rightErr != nil {
-					return 0, rightErr
-				}
-				return leftCount + rightCount, nil
+				return s.runSplitAttemptsAtomically(ctx, client, config, []exportAttempt{leftAttempt, rightAttempt}, mainStagingFile, obfuscator, retryCount, stats)
 			}
 		}
 		if nextStep, ok := nextAutopilotStep(attempt.StepSeconds, config.Safety); ok {
@@ -406,6 +394,40 @@ func (s *exportServiceImpl) exportWindowAdaptive(
 	}
 
 	return 0, enrichAdaptiveError(kind, err, attempt, config.Safety.MinWindowSeconds)
+}
+
+func (s *exportServiceImpl) runSplitAttemptsAtomically(
+	ctx context.Context,
+	client *vm.Client,
+	config domain.ExportConfig,
+	children []exportAttempt,
+	mainStagingFile string,
+	obfuscator *obfuscation.Obfuscator,
+	retryCount *int,
+	stats *adaptiveExportStats,
+) (int, error) {
+	splitFile := fmt.Sprintf("%s.split.%d", mainStagingFile, time.Now().UnixNano())
+	if err := initializeStagingFile(splitFile, false); err != nil {
+		return 0, fmt.Errorf("failed to initialize split staging file: %w", err)
+	}
+
+	total := 0
+	for _, child := range children {
+		count, err := s.exportWindowAdaptive(ctx, client, config, child, splitFile, obfuscator, retryCount, stats)
+		if err != nil {
+			_ = os.Remove(splitFile)
+			return 0, err
+		}
+		total += count
+	}
+	if err := appendFile(mainStagingFile, splitFile); err != nil {
+		_ = os.Remove(splitFile)
+		return 0, err
+	}
+	if err := os.Remove(splitFile); err != nil {
+		log.Printf("[WARN] Failed to remove split staging file %s: %v", splitFile, err)
+	}
+	return total, nil
 }
 
 func (s *exportServiceImpl) fetchAndProcessAttempt(

--- a/internal/application/services/export_service.go
+++ b/internal/application/services/export_service.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -21,6 +22,21 @@ import (
 )
 
 const defaultBatchTimeout = 2 * time.Minute
+
+var (
+	metricSelectorPattern = regexp.MustCompile(`^([a-zA-Z_:][a-zA-Z0-9_:]*)\s*\{(.*)\}$`)
+	metricNamePattern     = regexp.MustCompile(`^[a-zA-Z_:][a-zA-Z0-9_:]*$`)
+	jobMatcherPattern     = regexp.MustCompile(`(^|,)\s*job\s*(=|!=|=~|!~)`)
+)
+
+type exportAttempt struct {
+	Selector      string
+	TimeRange     domain.TimeRange
+	UseQueryRange bool
+	Depth         int
+	Jobs          []string
+	Strategy      string
+}
 
 // ExportService interface for full export operations
 type ExportService interface {
@@ -74,26 +90,12 @@ func (s *exportServiceImpl) ExecuteExport(ctx context.Context, config domain.Exp
 	if config.StagingFile == "" {
 		config.StagingFile = filepath.Join(stagingDir, fmt.Sprintf("%s.partial.jsonl", exportID))
 	}
-	flags := os.O_CREATE | os.O_WRONLY
-	if config.ResumeFromBatch > 0 {
-		flags |= os.O_APPEND
-	} else {
-		flags |= os.O_TRUNC
+	if err := initializeStagingFile(config.StagingFile, config.ResumeFromBatch > 0); err != nil {
+		return nil, fmt.Errorf("failed to initialize staging file: %w", err)
 	}
-	stagingHandle, err := os.OpenFile(config.StagingFile, flags, 0o640)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create staging file: %w", err)
-	}
-	defer func() { _ = stagingHandle.Close() }()
-	stagingWriter := bufio.NewWriter(stagingHandle)
-	defer func() {
-		_ = stagingWriter.Flush()
-		_ = stagingHandle.Close()
-	}()
 
 	// Step 2: Export metrics from VictoriaMetrics in batches
 	client := s.clientFactory(config.Connection)
-	selector, useQueryRange := s.buildExportQuery(config)
 	batchWindows := CalculateBatchWindows(config.TimeRange, config.Batching)
 	metricsCount := 0
 	var obfuscator *obfuscation.Obfuscator
@@ -118,22 +120,12 @@ func (s *exportServiceImpl) ExecuteExport(ctx context.Context, config domain.Exp
 			batchIndex+1, len(batchWindows), window.Start.Format(time.RFC3339), window.End.Format(time.RFC3339))
 		batchStart := time.Now()
 
-		batchCtx, cancelBatch := context.WithTimeout(ctx, defaultBatchTimeout)
-		exportReader, err := s.fetchBatch(batchCtx, client, selector, window, config.MetricStepSeconds, useQueryRange)
-		if err != nil {
-			cancelBatch()
-			return nil, err
-		}
-
-		batchCount, err := s.processMetricsIntoWriter(exportReader, config.Obfuscation, obfuscator, stagingWriter)
-		_ = exportReader.Close()
-		cancelBatch()
+		attempt := s.newExportAttempt(config, window)
+		retryCount := 0
+		batchCount, err := s.exportWindowAdaptive(ctx, client, config, attempt, config.StagingFile, obfuscator, &retryCount)
 		if err != nil {
 			fmt.Printf("[ERROR] Metrics processing failed for batch %d: %v\n", batchIndex+1, err)
 			return nil, fmt.Errorf("metrics processing failed: %w", err)
-		}
-		if err := stagingWriter.Flush(); err != nil {
-			return nil, fmt.Errorf("failed to flush staging file: %w", err)
 		}
 
 		metricsCount += batchCount
@@ -205,6 +197,20 @@ func (s *exportServiceImpl) ExecuteExport(ctx context.Context, config domain.Exp
 	return result, nil
 }
 
+func initializeStagingFile(path string, preserve bool) error {
+	flags := os.O_CREATE | os.O_WRONLY
+	if preserve {
+		flags |= os.O_APPEND
+	} else {
+		flags |= os.O_TRUNC
+	}
+	handle, err := os.OpenFile(path, flags, 0o640)
+	if err != nil {
+		return err
+	}
+	return handle.Close()
+}
+
 func (s *exportServiceImpl) exportToWriter(ctx context.Context, config domain.ExportConfig, writer io.Writer) (int, error) {
 	client := s.clientFactory(config.Connection)
 	selector, useQueryRange := s.buildExportQuery(config)
@@ -239,6 +245,174 @@ func (s *exportServiceImpl) exportToWriter(ctx context.Context, config domain.Ex
 		return 0, fmt.Errorf("flush error: %w", err)
 	}
 	return metricsCount, nil
+}
+
+func (s *exportServiceImpl) newExportAttempt(config domain.ExportConfig, tr domain.TimeRange) exportAttempt {
+	selector, useQueryRange := s.buildExportQuery(config)
+	strategy := "export"
+	if useQueryRange {
+		strategy = "query_range"
+	}
+	return exportAttempt{
+		Selector:      selector,
+		TimeRange:     tr,
+		UseQueryRange: useQueryRange,
+		Jobs:          uniqueStrings(config.Jobs),
+		Strategy:      strategy,
+	}
+}
+
+func (s *exportServiceImpl) exportWindowAdaptive(
+	ctx context.Context,
+	client *vm.Client,
+	config domain.ExportConfig,
+	attempt exportAttempt,
+	mainStagingFile string,
+	obfuscator *obfuscation.Obfuscator,
+	retryCount *int,
+) (int, error) {
+	attemptFile := fmt.Sprintf("%s.attempt.%d", mainStagingFile, time.Now().UnixNano())
+	count, err := s.fetchAndProcessAttempt(ctx, client, config, attempt, obfuscator, attemptFile)
+	if err == nil {
+		if err := appendFile(mainStagingFile, attemptFile); err != nil {
+			_ = os.Remove(attemptFile)
+			return 0, err
+		}
+		_ = os.Remove(attemptFile)
+		return count, nil
+	}
+	_ = os.Remove(attemptFile)
+
+	kind := vm.ErrorKindOf(err)
+	if !config.Safety.AutoSplit || attempt.Depth >= config.Safety.MaxSplitDepth {
+		return 0, enrichAdaptiveError(kind, err, attempt, config.Safety.MinWindowSeconds)
+	}
+
+	switch {
+	case kind == vm.ErrorKindMissingRoute && !attempt.UseQueryRange:
+		*retryCount++
+		ReportAdaptiveRetry(ctx, AdaptiveRetryProgress{
+			Retries:   *retryCount,
+			TimeRange: attempt.TimeRange,
+			ErrorKind: string(kind),
+			Strategy:  "query_range",
+		})
+		next := attempt
+		next.UseQueryRange = true
+		next.Depth++
+		next.Strategy = "query_range"
+		return s.exportWindowAdaptive(ctx, client, config, next, mainStagingFile, obfuscator, retryCount)
+	case kind == vm.ErrorKindTooManySeries && config.Safety.SplitByJob && len(attempt.Jobs) > 1:
+		*retryCount++
+		ReportAdaptiveRetry(ctx, AdaptiveRetryProgress{
+			Retries:   *retryCount,
+			TimeRange: attempt.TimeRange,
+			ErrorKind: string(kind),
+			Strategy:  "split_by_job",
+		})
+		total := 0
+		for _, job := range attempt.Jobs {
+			child, ok := s.buildJobSplitAttempt(config, attempt, job)
+			if !ok {
+				return 0, enrichAdaptiveError(kind, err, attempt, config.Safety.MinWindowSeconds)
+			}
+			child.Depth = attempt.Depth + 1
+			count, childErr := s.exportWindowAdaptive(ctx, client, config, child, mainStagingFile, obfuscator, retryCount)
+			if childErr != nil {
+				return 0, childErr
+			}
+			total += count
+		}
+		return total, nil
+	case kind == vm.ErrorKindQueryTimeout && attempt.UseQueryRange:
+		left, right, ok := splitTimeRange(attempt.TimeRange, config.Safety.MinWindowSeconds)
+		if !ok {
+			return 0, enrichAdaptiveError(kind, err, attempt, config.Safety.MinWindowSeconds)
+		}
+		*retryCount++
+		ReportAdaptiveRetry(ctx, AdaptiveRetryProgress{
+			Retries:   *retryCount,
+			TimeRange: attempt.TimeRange,
+			ErrorKind: string(kind),
+			Strategy:  "split_by_time",
+		})
+		leftAttempt := attempt
+		leftAttempt.TimeRange = left
+		leftAttempt.Depth = attempt.Depth + 1
+		leftAttempt.Strategy = "query_range"
+		rightAttempt := attempt
+		rightAttempt.TimeRange = right
+		rightAttempt.Depth = attempt.Depth + 1
+		rightAttempt.Strategy = "query_range"
+
+		leftCount, leftErr := s.exportWindowAdaptive(ctx, client, config, leftAttempt, mainStagingFile, obfuscator, retryCount)
+		if leftErr != nil {
+			return 0, leftErr
+		}
+		rightCount, rightErr := s.exportWindowAdaptive(ctx, client, config, rightAttempt, mainStagingFile, obfuscator, retryCount)
+		if rightErr != nil {
+			return 0, rightErr
+		}
+		return leftCount + rightCount, nil
+	default:
+		return 0, enrichAdaptiveError(kind, err, attempt, config.Safety.MinWindowSeconds)
+	}
+}
+
+func (s *exportServiceImpl) fetchAndProcessAttempt(
+	ctx context.Context,
+	client *vm.Client,
+	config domain.ExportConfig,
+	attempt exportAttempt,
+	obfuscator *obfuscation.Obfuscator,
+	attemptFile string,
+) (int, error) {
+	handle, err := os.OpenFile(attemptFile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o640)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create attempt file: %w", err)
+	}
+	defer func() { _ = handle.Close() }()
+
+	writer := bufio.NewWriter(handle)
+	defer func() { _ = writer.Flush() }()
+
+	batchCtx, cancelBatch := context.WithTimeout(ctx, defaultBatchTimeout)
+	defer cancelBatch()
+
+	exportReader, err := s.fetchBatch(batchCtx, client, attempt.Selector, attempt.TimeRange, config.MetricStepSeconds, attempt.UseQueryRange)
+	if err != nil {
+		return 0, err
+	}
+	count, err := s.processMetricsIntoWriter(exportReader, config.Obfuscation, obfuscator, writer)
+	if closeErr := exportReader.Close(); closeErr != nil && err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return 0, err
+	}
+	if err := writer.Flush(); err != nil {
+		return 0, fmt.Errorf("failed to flush attempt file: %w", err)
+	}
+	return count, nil
+}
+
+func appendFile(destination, source string) error {
+	src, err := os.Open(source)
+	if err != nil {
+		return fmt.Errorf("failed to open attempt file: %w", err)
+	}
+	defer func() { _ = src.Close() }()
+
+	dst, err := os.OpenFile(destination, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o640)
+	if err != nil {
+		return fmt.Errorf("failed to append staging file: %w", err)
+	}
+	defer func() { _ = dst.Close() }()
+
+	if _, err := io.Copy(dst, src); err != nil {
+		return fmt.Errorf("failed to append attempt output: %w", err)
+	}
+	return nil
 }
 
 // processMetrics processes exported metrics with optional obfuscation
@@ -412,6 +586,9 @@ func (s *exportServiceImpl) buildExportQuery(config domain.ExportConfig) (string
 		case domain.QueryModeSelector:
 			selector := config.Query
 			if len(config.Jobs) > 0 {
+				if rewritten, ok := applyJobMatcherToSelector(selector, config.Jobs); ok {
+					return rewritten, false
+				}
 				filter := buildJobFilterSelector(config.Jobs)
 				selector = fmt.Sprintf("(%s) and on(job) %s", selector, filter)
 				return selector, true
@@ -425,6 +602,77 @@ func (s *exportServiceImpl) buildExportQuery(config domain.ExportConfig) (string
 	}
 
 	return s.buildSelector(config.Jobs), false
+}
+
+func (s *exportServiceImpl) buildJobSplitAttempt(config domain.ExportConfig, parent exportAttempt, job string) (exportAttempt, bool) {
+	child := exportAttempt{
+		TimeRange: parent.TimeRange,
+		Jobs:      []string{job},
+	}
+
+	switch {
+	case config.Mode == domain.ExportModeCustom && config.QueryType == domain.QueryModeSelector:
+		if rewritten, ok := applyJobMatcherToSelector(config.Query, []string{job}); ok {
+			child.Selector = rewritten
+			child.UseQueryRange = false
+			child.Strategy = "export"
+			return child, true
+		}
+		filter := buildJobFilterSelector([]string{job})
+		child.Selector = fmt.Sprintf("(%s) and on(job) %s", config.Query, filter)
+		child.UseQueryRange = true
+		child.Strategy = "query_range"
+		return child, true
+	case config.Mode == domain.ExportModeCluster:
+		child.Selector = s.buildSelector([]string{job})
+		child.UseQueryRange = false
+		child.Strategy = "export"
+		return child, true
+	default:
+		return exportAttempt{}, false
+	}
+}
+
+func applyJobMatcherToSelector(selector string, jobs []string) (string, bool) {
+	trimmed := strings.TrimSpace(selector)
+	if trimmed == "" || len(jobs) == 0 {
+		return "", false
+	}
+	jobMatcher := buildJobFilterSelector(jobs)
+	jobMatcher = strings.TrimPrefix(strings.TrimSuffix(jobMatcher, "}"), "{")
+
+	if strings.HasPrefix(trimmed, "{") && strings.HasSuffix(trimmed, "}") {
+		inside := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(trimmed, "{"), "}"))
+		if containsJobMatcher(inside) {
+			return "", false
+		}
+		if inside == "" {
+			return fmt.Sprintf("{%s}", jobMatcher), true
+		}
+		return fmt.Sprintf("{%s,%s}", inside, jobMatcher), true
+	}
+
+	if matches := metricSelectorPattern.FindStringSubmatch(trimmed); len(matches) == 3 {
+		metricName := matches[1]
+		inside := strings.TrimSpace(matches[2])
+		if containsJobMatcher(inside) {
+			return "", false
+		}
+		if inside == "" {
+			return fmt.Sprintf("%s{%s}", metricName, jobMatcher), true
+		}
+		return fmt.Sprintf("%s{%s,%s}", metricName, inside, jobMatcher), true
+	}
+
+	if metricNamePattern.MatchString(trimmed) {
+		return fmt.Sprintf("%s{%s}", trimmed, jobMatcher), true
+	}
+
+	return "", false
+}
+
+func containsJobMatcher(selectorBody string) bool {
+	return jobMatcherPattern.MatchString(selectorBody)
 }
 
 // buildArchiveMetadata builds archive metadata from export config
@@ -458,36 +706,7 @@ func (s *exportServiceImpl) buildArchiveMetadata(
 
 // isMissingRouteError checks if error is due to missing export route
 func (s *exportServiceImpl) isMissingRouteError(err error) bool {
-	if err == nil {
-		return false
-	}
-	errMsg := err.Error()
-	return containsAny(errMsg, []string{
-		"missing route",
-		"404",
-		"not found",
-		"unsupported path",
-	})
-}
-
-// containsAny checks if string contains any of the substrings (case-insensitive)
-func containsAny(s string, substrs []string) bool {
-	s = toLower(s)
-	for _, substr := range substrs {
-		if contains(s, toLower(substr)) {
-			return true
-		}
-	}
-	return false
-}
-
-// Helper functions for string operations
-func toLower(s string) string {
-	return strings.ToLower(s)
-}
-
-func contains(s, substr string) bool {
-	return strings.Contains(s, substr)
+	return vm.ErrorKindOf(err) == vm.ErrorKindMissingRoute
 }
 
 func uniqueStrings(values []string) []string {
@@ -504,6 +723,37 @@ func uniqueStrings(values []string) []string {
 		result = append(result, v)
 	}
 	return result
+}
+
+func splitTimeRange(tr domain.TimeRange, minWindowSeconds int) (domain.TimeRange, domain.TimeRange, bool) {
+	minWindow := time.Duration(minWindowSeconds) * time.Second
+	if minWindowSeconds <= 0 {
+		minWindow = 5 * time.Second
+	}
+	duration := tr.End.Sub(tr.Start)
+	if duration <= minWindow {
+		return domain.TimeRange{}, domain.TimeRange{}, false
+	}
+
+	mid := tr.Start.Add(duration / 2)
+	if !mid.After(tr.Start) || !tr.End.After(mid) {
+		return domain.TimeRange{}, domain.TimeRange{}, false
+	}
+	return domain.TimeRange{Start: tr.Start, End: mid}, domain.TimeRange{Start: mid, End: tr.End}, true
+}
+
+func enrichAdaptiveError(kind vm.ErrorKind, err error, attempt exportAttempt, minWindowSeconds int) error {
+	switch kind {
+	case vm.ErrorKindQueryTimeout:
+		return fmt.Errorf("query still exceeds VictoriaMetrics -search.maxQueryDuration after splitting down to %ds windows; narrow selector/query or use raw selector export: %w", minWindowSeconds, err)
+	case vm.ErrorKindTooManySeries:
+		return fmt.Errorf("query exceeds VictoriaMetrics series limits; narrow selector/query or adjust VictoriaMetrics -search.maxExportSeries / -search.maxUniqueTimeseries: %w", err)
+	default:
+		if attempt.UseQueryRange {
+			return fmt.Errorf("adaptive export failed while using query_range: %w", err)
+		}
+		return err
+	}
 }
 
 func determineQueryRangeStep(tr domain.TimeRange, overrideSeconds int) time.Duration {

--- a/internal/application/services/export_service.go
+++ b/internal/application/services/export_service.go
@@ -312,7 +312,7 @@ func (s *exportServiceImpl) exportWindowAdaptive(
 	kind := vm.ErrorKindOf(err)
 
 	switch {
-	case kind == vm.ErrorKindMissingRoute && !attempt.UseQueryRange && config.Safety.AutoSplit && attempt.Depth < config.Safety.MaxSplitDepth:
+	case kind == vm.ErrorKindMissingRoute && !attempt.UseQueryRange:
 		*retryCount++
 		progress := AdaptiveRetryProgress{
 			Retries:   *retryCount,

--- a/internal/application/services/export_service.go
+++ b/internal/application/services/export_service.go
@@ -407,10 +407,13 @@ func appendFile(destination, source string) error {
 	if err != nil {
 		return fmt.Errorf("failed to append staging file: %w", err)
 	}
-	defer func() { _ = dst.Close() }()
 
 	if _, err := io.Copy(dst, src); err != nil {
+		_ = dst.Close()
 		return fmt.Errorf("failed to append attempt output: %w", err)
+	}
+	if err := dst.Close(); err != nil {
+		return fmt.Errorf("failed to close staging file after append: %w", err)
 	}
 	return nil
 }

--- a/internal/application/services/export_service.go
+++ b/internal/application/services/export_service.go
@@ -36,6 +36,14 @@ type exportAttempt struct {
 	Depth         int
 	Jobs          []string
 	Strategy      string
+	StepSeconds   int
+}
+
+type adaptiveExportStats struct {
+	Mode               domain.ExportAdaptivityMode
+	MaxStepSecondsUsed int
+	Sampled            bool
+	Decisions          []archive.AdaptiveDecision
 }
 
 // ExportService interface for full export operations
@@ -76,6 +84,8 @@ func ExportToWriter(ctx context.Context, config domain.ExportConfig, writer io.W
 
 // ExecuteExport performs full metrics export with optional obfuscation
 func (s *exportServiceImpl) ExecuteExport(ctx context.Context, config domain.ExportConfig) (*domain.ExportResult, error) {
+	applyExportServiceDefaults(&config)
+
 	// Generate export ID
 	exportID := s.generateExportID()
 
@@ -102,6 +112,10 @@ func (s *exportServiceImpl) ExecuteExport(ctx context.Context, config domain.Exp
 	if config.Obfuscation.Enabled {
 		obfuscator = obfuscation.NewObfuscator()
 	}
+	adaptiveStats := &adaptiveExportStats{
+		Mode:               config.Safety.Mode,
+		MaxStepSecondsUsed: config.MetricStepSeconds,
+	}
 
 	startIdx := config.ResumeFromBatch
 	if startIdx < 0 || startIdx >= len(batchWindows) {
@@ -122,7 +136,7 @@ func (s *exportServiceImpl) ExecuteExport(ctx context.Context, config domain.Exp
 
 		attempt := s.newExportAttempt(config, window)
 		retryCount := 0
-		batchCount, err := s.exportWindowAdaptive(ctx, client, config, attempt, config.StagingFile, obfuscator, &retryCount)
+		batchCount, err := s.exportWindowAdaptive(ctx, client, config, attempt, config.StagingFile, obfuscator, &retryCount, adaptiveStats)
 		if err != nil {
 			fmt.Printf("[ERROR] Metrics processing failed for batch %d: %v\n", batchIndex+1, err)
 			return nil, fmt.Errorf("metrics processing failed: %w", err)
@@ -150,7 +164,7 @@ func (s *exportServiceImpl) ExecuteExport(ctx context.Context, config domain.Exp
 
 	// Step 3: Create archive
 	fmt.Printf("Creating archive...\n")
-	metadata := s.buildArchiveMetadata(exportID, config, metricsCount, obfuscationMaps)
+	metadata := s.buildArchiveMetadata(exportID, config, metricsCount, obfuscationMaps, adaptiveStats)
 	processedReader, err := os.Open(config.StagingFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open staging file for archive: %w", err)
@@ -212,6 +226,8 @@ func initializeStagingFile(path string, preserve bool) error {
 }
 
 func (s *exportServiceImpl) exportToWriter(ctx context.Context, config domain.ExportConfig, writer io.Writer) (int, error) {
+	applyExportServiceDefaults(&config)
+
 	client := s.clientFactory(config.Connection)
 	selector, useQueryRange := s.buildExportQuery(config)
 	batchWindows := CalculateBatchWindows(config.TimeRange, config.Batching)
@@ -247,6 +263,14 @@ func (s *exportServiceImpl) exportToWriter(ctx context.Context, config domain.Ex
 	return metricsCount, nil
 }
 
+func applyExportServiceDefaults(config *domain.ExportConfig) {
+	originalBatching := config.Batching
+	ApplyExportDefaults(config)
+	if !originalBatching.Enabled && originalBatching.Strategy == "" && originalBatching.CustomIntervalSecs == 0 {
+		config.Batching = originalBatching
+	}
+}
+
 func (s *exportServiceImpl) newExportAttempt(config domain.ExportConfig, tr domain.TimeRange) exportAttempt {
 	selector, useQueryRange := s.buildExportQuery(config)
 	strategy := "export"
@@ -259,6 +283,7 @@ func (s *exportServiceImpl) newExportAttempt(config domain.ExportConfig, tr doma
 		UseQueryRange: useQueryRange,
 		Jobs:          uniqueStrings(config.Jobs),
 		Strategy:      strategy,
+		StepSeconds:   config.MetricStepSeconds,
 	}
 }
 
@@ -270,9 +295,10 @@ func (s *exportServiceImpl) exportWindowAdaptive(
 	mainStagingFile string,
 	obfuscator *obfuscation.Obfuscator,
 	retryCount *int,
+	stats *adaptiveExportStats,
 ) (int, error) {
 	attemptFile := fmt.Sprintf("%s.attempt.%d", mainStagingFile, time.Now().UnixNano())
-	count, err := s.fetchAndProcessAttempt(ctx, client, config, attempt, obfuscator, attemptFile)
+	count, err := s.fetchAndProcessAttempt(ctx, client, config, attempt, obfuscator, attemptFile, stats)
 	if err == nil {
 		if err := appendFile(mainStagingFile, attemptFile); err != nil {
 			_ = os.Remove(attemptFile)
@@ -284,32 +310,33 @@ func (s *exportServiceImpl) exportWindowAdaptive(
 	_ = os.Remove(attemptFile)
 
 	kind := vm.ErrorKindOf(err)
-	if !config.Safety.AutoSplit || attempt.Depth >= config.Safety.MaxSplitDepth {
-		return 0, enrichAdaptiveError(kind, err, attempt, config.Safety.MinWindowSeconds)
-	}
 
 	switch {
-	case kind == vm.ErrorKindMissingRoute && !attempt.UseQueryRange:
+	case kind == vm.ErrorKindMissingRoute && !attempt.UseQueryRange && config.Safety.AutoSplit && attempt.Depth < config.Safety.MaxSplitDepth:
 		*retryCount++
-		ReportAdaptiveRetry(ctx, AdaptiveRetryProgress{
+		progress := AdaptiveRetryProgress{
 			Retries:   *retryCount,
 			TimeRange: attempt.TimeRange,
 			ErrorKind: string(kind),
 			Strategy:  "query_range",
-		})
+		}
+		ReportAdaptiveRetry(ctx, progress)
+		recordAdaptiveDecision(stats, progress)
 		next := attempt
 		next.UseQueryRange = true
 		next.Depth++
 		next.Strategy = "query_range"
-		return s.exportWindowAdaptive(ctx, client, config, next, mainStagingFile, obfuscator, retryCount)
-	case kind == vm.ErrorKindTooManySeries && config.Safety.SplitByJob && len(attempt.Jobs) > 1:
+		return s.exportWindowAdaptive(ctx, client, config, next, mainStagingFile, obfuscator, retryCount, stats)
+	case kind == vm.ErrorKindTooManySeries && config.Safety.AutoSplit && attempt.Depth < config.Safety.MaxSplitDepth && config.Safety.SplitByJob && len(attempt.Jobs) > 1:
 		*retryCount++
-		ReportAdaptiveRetry(ctx, AdaptiveRetryProgress{
+		progress := AdaptiveRetryProgress{
 			Retries:   *retryCount,
 			TimeRange: attempt.TimeRange,
 			ErrorKind: string(kind),
 			Strategy:  "split_by_job",
-		})
+		}
+		ReportAdaptiveRetry(ctx, progress)
+		recordAdaptiveDecision(stats, progress)
 		total := 0
 		for _, job := range attempt.Jobs {
 			child, ok := s.buildJobSplitAttempt(config, attempt, job)
@@ -317,7 +344,7 @@ func (s *exportServiceImpl) exportWindowAdaptive(
 				return 0, enrichAdaptiveError(kind, err, attempt, config.Safety.MinWindowSeconds)
 			}
 			child.Depth = attempt.Depth + 1
-			count, childErr := s.exportWindowAdaptive(ctx, client, config, child, mainStagingFile, obfuscator, retryCount)
+			count, childErr := s.exportWindowAdaptive(ctx, client, config, child, mainStagingFile, obfuscator, retryCount, stats)
 			if childErr != nil {
 				return 0, childErr
 			}
@@ -325,38 +352,60 @@ func (s *exportServiceImpl) exportWindowAdaptive(
 		}
 		return total, nil
 	case kind == vm.ErrorKindQueryTimeout && attempt.UseQueryRange:
-		left, right, ok := splitTimeRange(attempt.TimeRange, config.Safety.MinWindowSeconds)
-		if !ok {
-			return 0, enrichAdaptiveError(kind, err, attempt, config.Safety.MinWindowSeconds)
-		}
-		*retryCount++
-		ReportAdaptiveRetry(ctx, AdaptiveRetryProgress{
-			Retries:   *retryCount,
-			TimeRange: attempt.TimeRange,
-			ErrorKind: string(kind),
-			Strategy:  "split_by_time",
-		})
-		leftAttempt := attempt
-		leftAttempt.TimeRange = left
-		leftAttempt.Depth = attempt.Depth + 1
-		leftAttempt.Strategy = "query_range"
-		rightAttempt := attempt
-		rightAttempt.TimeRange = right
-		rightAttempt.Depth = attempt.Depth + 1
-		rightAttempt.Strategy = "query_range"
+		if config.Safety.AutoSplit && attempt.Depth < config.Safety.MaxSplitDepth {
+			left, right, ok := splitTimeRange(attempt.TimeRange, config.Safety.MinWindowSeconds)
+			if ok {
+				*retryCount++
+				progress := AdaptiveRetryProgress{
+					Retries:     *retryCount,
+					TimeRange:   attempt.TimeRange,
+					ErrorKind:   string(kind),
+					Strategy:    "split_by_time",
+					StepSeconds: attempt.StepSeconds,
+				}
+				ReportAdaptiveRetry(ctx, progress)
+				recordAdaptiveDecision(stats, progress)
+				leftAttempt := attempt
+				leftAttempt.TimeRange = left
+				leftAttempt.Depth = attempt.Depth + 1
+				leftAttempt.Strategy = "query_range"
+				rightAttempt := attempt
+				rightAttempt.TimeRange = right
+				rightAttempt.Depth = attempt.Depth + 1
+				rightAttempt.Strategy = "query_range"
 
-		leftCount, leftErr := s.exportWindowAdaptive(ctx, client, config, leftAttempt, mainStagingFile, obfuscator, retryCount)
-		if leftErr != nil {
-			return 0, leftErr
+				leftCount, leftErr := s.exportWindowAdaptive(ctx, client, config, leftAttempt, mainStagingFile, obfuscator, retryCount, stats)
+				if leftErr != nil {
+					return 0, leftErr
+				}
+				rightCount, rightErr := s.exportWindowAdaptive(ctx, client, config, rightAttempt, mainStagingFile, obfuscator, retryCount, stats)
+				if rightErr != nil {
+					return 0, rightErr
+				}
+				return leftCount + rightCount, nil
+			}
 		}
-		rightCount, rightErr := s.exportWindowAdaptive(ctx, client, config, rightAttempt, mainStagingFile, obfuscator, retryCount)
-		if rightErr != nil {
-			return 0, rightErr
+		if nextStep, ok := nextAutopilotStep(attempt.StepSeconds, config.Safety); ok {
+			*retryCount++
+			progress := AdaptiveRetryProgress{
+				Retries:     *retryCount,
+				TimeRange:   attempt.TimeRange,
+				ErrorKind:   string(kind),
+				Strategy:    "increase_step",
+				StepSeconds: nextStep,
+			}
+			ReportAdaptiveRetry(ctx, progress)
+			recordAdaptiveDecision(stats, progress)
+			next := attempt
+			next.StepSeconds = nextStep
+			next.Depth = 0
+			next.Strategy = "query_range"
+			return s.exportWindowAdaptive(ctx, client, config, next, mainStagingFile, obfuscator, retryCount, stats)
 		}
-		return leftCount + rightCount, nil
 	default:
-		return 0, enrichAdaptiveError(kind, err, attempt, config.Safety.MinWindowSeconds)
 	}
+
+	return 0, enrichAdaptiveError(kind, err, attempt, config.Safety.MinWindowSeconds)
 }
 
 func (s *exportServiceImpl) fetchAndProcessAttempt(
@@ -366,6 +415,7 @@ func (s *exportServiceImpl) fetchAndProcessAttempt(
 	attempt exportAttempt,
 	obfuscator *obfuscation.Obfuscator,
 	attemptFile string,
+	stats *adaptiveExportStats,
 ) (int, error) {
 	handle, err := os.OpenFile(attemptFile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o640)
 	if err != nil {
@@ -374,12 +424,11 @@ func (s *exportServiceImpl) fetchAndProcessAttempt(
 	defer func() { _ = handle.Close() }()
 
 	writer := bufio.NewWriter(handle)
-	defer func() { _ = writer.Flush() }()
 
 	batchCtx, cancelBatch := context.WithTimeout(ctx, defaultBatchTimeout)
 	defer cancelBatch()
 
-	exportReader, err := s.fetchBatch(batchCtx, client, attempt.Selector, attempt.TimeRange, config.MetricStepSeconds, attempt.UseQueryRange)
+	exportReader, err := s.fetchAttemptReader(batchCtx, client, attempt)
 	if err != nil {
 		return 0, err
 	}
@@ -393,6 +442,10 @@ func (s *exportServiceImpl) fetchAndProcessAttempt(
 	if err := writer.Flush(); err != nil {
 		return 0, fmt.Errorf("failed to flush attempt file: %w", err)
 	}
+	if err := handle.Close(); err != nil {
+		return 0, fmt.Errorf("failed to close attempt file: %w", err)
+	}
+	recordAttemptSuccess(stats, attempt)
 	return count, nil
 }
 
@@ -609,8 +662,9 @@ func (s *exportServiceImpl) buildExportQuery(config domain.ExportConfig) (string
 
 func (s *exportServiceImpl) buildJobSplitAttempt(config domain.ExportConfig, parent exportAttempt, job string) (exportAttempt, bool) {
 	child := exportAttempt{
-		TimeRange: parent.TimeRange,
-		Jobs:      []string{job},
+		TimeRange:   parent.TimeRange,
+		Jobs:        []string{job},
+		StepSeconds: parent.StepSeconds,
 	}
 
 	switch {
@@ -678,22 +732,78 @@ func containsJobMatcher(selectorBody string) bool {
 	return jobMatcherPattern.MatchString(selectorBody)
 }
 
+func nextAutopilotStep(current int, safety domain.ExportSafetyConfig) (int, bool) {
+	if safety.Mode != domain.ExportAdaptivityAutopilot {
+		return 0, false
+	}
+	for _, step := range normalizeStepLadder(safety.StepLadderSeconds, safety.MaxStepSeconds) {
+		if step > current {
+			return step, true
+		}
+	}
+	return 0, false
+}
+
+func recordAdaptiveDecision(stats *adaptiveExportStats, progress AdaptiveRetryProgress) {
+	if stats == nil {
+		return
+	}
+	stats.Decisions = append(stats.Decisions, archive.AdaptiveDecision{
+		Strategy:    progress.Strategy,
+		ErrorKind:   progress.ErrorKind,
+		TimeRange:   progress.TimeRange,
+		StepSeconds: progress.StepSeconds,
+	})
+	if progress.StepSeconds > stats.MaxStepSecondsUsed {
+		stats.MaxStepSecondsUsed = progress.StepSeconds
+	}
+	if progress.Strategy == "increase_step" {
+		stats.Sampled = true
+	}
+}
+
+func recordAttemptSuccess(stats *adaptiveExportStats, attempt exportAttempt) {
+	if stats == nil {
+		return
+	}
+	if attempt.UseQueryRange {
+		stats.Sampled = true
+	}
+	if attempt.StepSeconds > stats.MaxStepSecondsUsed {
+		stats.MaxStepSecondsUsed = attempt.StepSeconds
+	}
+}
+
 // buildArchiveMetadata builds archive metadata from export config
 func (s *exportServiceImpl) buildArchiveMetadata(
 	exportID string,
 	config domain.ExportConfig,
 	metricsCount int,
 	obfuscationMaps map[string]map[string]string,
+	adaptiveStats *adaptiveExportStats,
 ) archive.ArchiveMetadata {
 	metadata := archive.ArchiveMetadata{
-		ExportID:        exportID,
-		ExportDate:      time.Now().UTC(),
-		TimeRange:       config.TimeRange,
-		Components:      uniqueStrings(config.Components),
-		Jobs:            uniqueStrings(config.Jobs),
-		MetricsCount:    metricsCount,
-		Obfuscated:      config.Obfuscation.Enabled,
-		VMGatherVersion: s.vmGatherVersion,
+		ExportID:             exportID,
+		ExportDate:           time.Now().UTC(),
+		TimeRange:            config.TimeRange,
+		Components:           uniqueStrings(config.Components),
+		Jobs:                 uniqueStrings(config.Jobs),
+		MetricsCount:         metricsCount,
+		Obfuscated:           config.Obfuscation.Enabled,
+		AdaptiveMode:         string(config.Safety.Mode),
+		MetricStepSeconds:    config.MetricStepSeconds,
+		MaxMetricStepSeconds: config.Safety.MaxStepSeconds,
+		VMGatherVersion:      s.vmGatherVersion,
+	}
+	if adaptiveStats != nil {
+		metadata.AdaptiveMode = string(adaptiveStats.Mode)
+		metadata.Sampled = adaptiveStats.Sampled
+		if adaptiveStats.Sampled {
+			metadata.MetricStepSeconds = adaptiveStats.MaxStepSecondsUsed
+		} else {
+			metadata.MetricStepSeconds = 0
+		}
+		metadata.AdaptiveDecisions = append([]archive.AdaptiveDecision(nil), adaptiveStats.Decisions...)
 	}
 
 	// Add obfuscation maps if present
@@ -748,7 +858,7 @@ func splitTimeRange(tr domain.TimeRange, minWindowSeconds int) (domain.TimeRange
 func enrichAdaptiveError(kind vm.ErrorKind, err error, attempt exportAttempt, minWindowSeconds int) error {
 	switch kind {
 	case vm.ErrorKindQueryTimeout:
-		return fmt.Errorf("query still exceeds VictoriaMetrics -search.maxQueryDuration after splitting down to %ds windows; narrow selector/query or use raw selector export: %w", minWindowSeconds, err)
+		return fmt.Errorf("query still exceeds VictoriaMetrics -search.maxQueryDuration after splitting down to %ds windows and sampling at %ds; narrow selector/query or use raw selector export: %w", minWindowSeconds, attempt.StepSeconds, err)
 	case vm.ErrorKindTooManySeries:
 		return fmt.Errorf("query exceeds VictoriaMetrics series limits; narrow selector/query or adjust VictoriaMetrics -search.maxExportSeries / -search.maxUniqueTimeseries: %w", err)
 	default:
@@ -887,6 +997,19 @@ func (s *exportServiceImpl) fetchBatch(ctx context.Context, client *vm.Client, s
 		fmt.Printf("[WARN] Export API not available for current batch, falling back to query_range\n")
 		return s.exportViaQueryRange(ctx, client, selector, tr, metricStepSeconds)
 	}
+	if err != nil {
+		return nil, fmt.Errorf("export failed: %w", err)
+	}
+	return reader, nil
+}
+
+func (s *exportServiceImpl) fetchAttemptReader(ctx context.Context, client *vm.Client, attempt exportAttempt) (io.ReadCloser, error) {
+	fmt.Printf("Attempting export for batch: %s -> %s\n", attempt.TimeRange.Start.Format(time.RFC3339), attempt.TimeRange.End.Format(time.RFC3339))
+	if attempt.UseQueryRange {
+		fmt.Printf("[INFO] Using query_range export for custom query at %ds step\n", attempt.StepSeconds)
+		return s.exportViaQueryRange(ctx, client, attempt.Selector, attempt.TimeRange, attempt.StepSeconds)
+	}
+	reader, err := client.Export(ctx, attempt.Selector, attempt.TimeRange.Start, attempt.TimeRange.End)
 	if err != nil {
 		return nil, fmt.Errorf("export failed: %w", err)
 	}

--- a/internal/application/services/export_service_advanced_test.go
+++ b/internal/application/services/export_service_advanced_test.go
@@ -424,6 +424,7 @@ func TestExportService_BuildArchiveMetadata_EdgeCases(t *testing.T) {
 				tt.config,
 				tt.metricsCount,
 				tt.obfuscationMaps,
+				nil,
 			)
 
 			// Should not panic

--- a/internal/application/services/export_service_chunking_test.go
+++ b/internal/application/services/export_service_chunking_test.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -430,6 +432,78 @@ func TestAdaptiveRetryDoesNotAppendFailedPartialAttempt(t *testing.T) {
 	}
 	if lines != 3 {
 		t.Fatalf("expected only successful split output in archive, got %d lines", lines)
+	}
+}
+
+func TestSplitByTimeFailureDoesNotAppendPartialSubSplit(t *testing.T) {
+	start := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/query_range" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		startSecs, _ := strconv.ParseInt(r.URL.Query().Get("start"), 10, 64)
+		endSecs, _ := strconv.ParseInt(r.URL.Query().Get("end"), 10, 64)
+		rangeStart := time.Unix(startSecs, 0)
+		rangeEnd := time.Unix(endSecs, 0)
+		duration := rangeEnd.Sub(rangeStart)
+		switch {
+		case duration == 2*time.Hour:
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = io.WriteString(w, `{"status":"error","error":"timeout exceeded during query execution: 30.000 seconds"}`)
+		case duration == time.Hour && rangeStart.Equal(start):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "success",
+				"data": map[string]any{
+					"resultType": "matrix",
+					"result": []any{
+						map[string]any{
+							"metric": map[string]string{
+								"__name__": "vm_rows_inserted_total",
+								"job":      "vmagent",
+							},
+							"values": [][]any{{float64(rangeStart.Unix()), "1"}},
+						},
+					},
+				},
+			})
+		case duration == time.Hour && rangeStart.Equal(start.Add(time.Hour)):
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = io.WriteString(w, `bad request`)
+		default:
+			http.Error(w, fmt.Sprintf("unexpected range %s - %s", rangeStart, rangeEnd), http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	outputDir := t.TempDir()
+	stagingFile := filepath.Join(outputDir, "failed-time-split.partial.jsonl")
+	service := NewExportService(outputDir, "test")
+	cfg := domain.ExportConfig{
+		Connection: domain.VMConnection{URL: srv.URL},
+		TimeRange: domain.TimeRange{
+			Start: start,
+			End:   start.Add(2 * time.Hour),
+		},
+		Mode:        domain.ExportModeCustom,
+		QueryType:   domain.QueryModeMetricsQL,
+		Query:       `rate(vm_rows_inserted_total[5m])`,
+		Batching:    domain.BatchSettings{Enabled: false, Strategy: "manual"},
+		StagingFile: stagingFile,
+	}
+	ApplyExportDefaults(&cfg)
+
+	_, err := service.ExecuteExport(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected split failure")
+	}
+	data, readErr := os.ReadFile(stagingFile)
+	if readErr != nil {
+		t.Fatalf("failed to read staging file: %v", readErr)
+	}
+	if strings.TrimSpace(string(data)) != "" {
+		t.Fatalf("expected failed time split to leave main staging empty, got %s", string(data))
 	}
 }
 

--- a/internal/application/services/export_service_chunking_test.go
+++ b/internal/application/services/export_service_chunking_test.go
@@ -17,6 +17,16 @@ import (
 	"github.com/VictoriaMetrics/vmgather/internal/infrastructure/vm"
 )
 
+type exportMetadataForTest struct {
+	MetricStepSeconds int    `json:"metric_step_seconds"`
+	Sampled           bool   `json:"sampled"`
+	AdaptiveMode      string `json:"adaptive_mode"`
+	AdaptiveDecisions []struct {
+		Strategy    string `json:"strategy"`
+		StepSeconds int    `json:"step_seconds"`
+	} `json:"adaptive_decisions"`
+}
+
 func TestExportViaQueryRange_Chunking(t *testing.T) {
 	// We want to verify that a large time range is split into 1-hour chunks
 	startTime := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -201,6 +211,127 @@ func TestQueryRangeTimeoutStopsAtMinWindow(t *testing.T) {
 	}
 }
 
+func TestAutopilotIncreasesMetricStepAfterMinWindow(t *testing.T) {
+	var steps []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/query_range" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		step := r.URL.Query().Get("step")
+		steps = append(steps, step)
+		if step == "30s" {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = io.WriteString(w, `{"status":"error","error":"timeout exceeded during query execution: 30.000 seconds"}`)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": "success",
+			"data": map[string]any{
+				"resultType": "matrix",
+				"result": []any{
+					map[string]any{
+						"metric": map[string]string{
+							"__name__": "vm_rows_inserted_total",
+							"job":      "vmagent",
+						},
+						"values": [][]any{{float64(0), "1"}},
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	service := NewExportService(t.TempDir(), "test")
+	cfg := domain.ExportConfig{
+		Connection: domain.VMConnection{URL: srv.URL},
+		TimeRange: domain.TimeRange{
+			Start: time.Unix(0, 0),
+			End:   time.Unix(10, 0),
+		},
+		Mode:      domain.ExportModeCustom,
+		QueryType: domain.QueryModeMetricsQL,
+		Query:     `rate(vm_rows_inserted_total[5m])`,
+		Batching:  domain.BatchSettings{Enabled: false, Strategy: "manual"},
+		Safety: domain.ExportSafetyConfig{
+			Mode:              domain.ExportAdaptivityAutopilot,
+			AutoSplit:         true,
+			SplitByJob:        true,
+			MinWindowSeconds:  10,
+			MaxSplitDepth:     8,
+			MaxStepSeconds:    300,
+			StepLadderSeconds: []int{30, 60, 300},
+		},
+	}
+	ApplyExportDefaults(&cfg)
+
+	result, err := service.ExecuteExport(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("ExecuteExport failed: %v", err)
+	}
+	if result.MetricsExported != 1 {
+		t.Fatalf("expected one exported metric, got %d", result.MetricsExported)
+	}
+	if strings.Join(steps, ",") != "30s,60s" {
+		t.Fatalf("expected autopilot to retry with 60s step, got %v", steps)
+	}
+	metadata := readExportMetadataForTest(t, result.ArchivePath)
+	if !metadata.Sampled || metadata.MetricStepSeconds != 60 {
+		t.Fatalf("expected sampled metadata at 60s, got %+v", metadata)
+	}
+	if len(metadata.AdaptiveDecisions) == 0 || metadata.AdaptiveDecisions[len(metadata.AdaptiveDecisions)-1].Strategy != "increase_step" {
+		t.Fatalf("expected increase_step decision in metadata, got %+v", metadata.AdaptiveDecisions)
+	}
+}
+
+func TestAutopilotStopsAtFiveMinuteMetricStep(t *testing.T) {
+	var steps []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/query_range" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		steps = append(steps, r.URL.Query().Get("step"))
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = io.WriteString(w, `{"status":"error","error":"timeout exceeded during query execution: 30.000 seconds"}`)
+	}))
+	defer srv.Close()
+
+	service := NewExportService(t.TempDir(), "test")
+	cfg := domain.ExportConfig{
+		Connection: domain.VMConnection{URL: srv.URL},
+		TimeRange: domain.TimeRange{
+			Start: time.Unix(0, 0),
+			End:   time.Unix(10, 0),
+		},
+		Mode:      domain.ExportModeCustom,
+		QueryType: domain.QueryModeMetricsQL,
+		Query:     `rate(vm_rows_inserted_total[5m])`,
+		Batching:  domain.BatchSettings{Enabled: false, Strategy: "manual"},
+		Safety: domain.ExportSafetyConfig{
+			Mode:              domain.ExportAdaptivityAutopilot,
+			AutoSplit:         true,
+			SplitByJob:        true,
+			MinWindowSeconds:  10,
+			MaxSplitDepth:     8,
+			MaxStepSeconds:    300,
+			StepLadderSeconds: []int{30, 60, 120, 300, 600},
+		},
+	}
+	ApplyExportDefaults(&cfg)
+
+	_, err := service.ExecuteExport(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected timeout failure at max autopilot step")
+	}
+	if !strings.Contains(err.Error(), "sampling at 300s") {
+		t.Fatalf("expected max-step timeout error, got %v", err)
+	}
+	got := strings.Join(steps, ",")
+	if got != "30s,60s,120s,300s" {
+		t.Fatalf("expected retries to stop at 300s, got %v", steps)
+	}
+}
+
 func TestAdaptiveRetryDoesNotAppendFailedPartialAttempt(t *testing.T) {
 	start := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
 	var largeAttemptFailed bool
@@ -300,4 +431,31 @@ func TestAdaptiveRetryDoesNotAppendFailedPartialAttempt(t *testing.T) {
 	if lines != 3 {
 		t.Fatalf("expected only successful split output in archive, got %d lines", lines)
 	}
+}
+
+func readExportMetadataForTest(t *testing.T, archivePath string) exportMetadataForTest {
+	t.Helper()
+	archiveReader, err := zip.OpenReader(archivePath)
+	if err != nil {
+		t.Fatalf("failed to open archive: %v", err)
+	}
+	defer func() { _ = archiveReader.Close() }()
+	for _, file := range archiveReader.File {
+		if file.Name != "metadata.json" {
+			continue
+		}
+		rc, err := file.Open()
+		if err != nil {
+			t.Fatalf("failed to open metadata.json: %v", err)
+		}
+		var metadata exportMetadataForTest
+		err = json.NewDecoder(rc).Decode(&metadata)
+		_ = rc.Close()
+		if err != nil {
+			t.Fatalf("failed to decode metadata.json: %v", err)
+		}
+		return metadata
+	}
+	t.Fatal("metadata.json not found")
+	return exportMetadataForTest{}
 }

--- a/internal/application/services/export_service_chunking_test.go
+++ b/internal/application/services/export_service_chunking_test.go
@@ -1,12 +1,15 @@
 package services
 
 import (
+	"archive/zip"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -89,4 +92,212 @@ func TestExportViaQueryRange_Chunking(t *testing.T) {
 	}
 
 	t.Logf("Requests made: %v", requests)
+}
+
+func TestQueryRangeTimeoutSplitsTimeWindow(t *testing.T) {
+	var requests []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/query_range" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		startRaw := r.URL.Query().Get("start")
+		endRaw := r.URL.Query().Get("end")
+		startSecs, _ := strconv.ParseInt(startRaw, 10, 64)
+		endSecs, _ := strconv.ParseInt(endRaw, 10, 64)
+		startUnix := time.Unix(startSecs, 0)
+		endUnix := time.Unix(endSecs, 0)
+		duration := endUnix.Sub(startUnix)
+		requests = append(requests, duration.String())
+		if duration > 15*time.Second {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = io.WriteString(w, `{"status":"error","error":"timeout exceeded during query execution: 30.000 seconds"}`)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": "success",
+			"data": map[string]any{
+				"resultType": "matrix",
+				"result": []any{
+					map[string]any{
+						"metric": map[string]string{
+							"__name__": "vm_rows_inserted_total",
+							"job":      "vmagent",
+						},
+						"values": [][]any{{float64(startUnix.Unix()), "1"}},
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	service := NewExportService(t.TempDir(), "test")
+	cfg := domain.ExportConfig{
+		Connection: domain.VMConnection{URL: srv.URL},
+		TimeRange: domain.TimeRange{
+			Start: time.Unix(0, 0),
+			End:   time.Unix(60, 0),
+		},
+		Mode:      domain.ExportModeCustom,
+		QueryType: domain.QueryModeMetricsQL,
+		Query:     `rate(vm_rows_inserted_total[5m])`,
+		Batching:  domain.BatchSettings{Enabled: false, Strategy: "manual"},
+	}
+	ApplyExportDefaults(&cfg)
+
+	result, err := service.ExecuteExport(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("ExecuteExport failed: %v", err)
+	}
+	if result.MetricsExported == 0 {
+		t.Fatalf("expected exported metrics, got %+v", result)
+	}
+	if len(requests) < 3 {
+		t.Fatalf("expected split query_range requests, got %v", requests)
+	}
+}
+
+func TestQueryRangeTimeoutStopsAtMinWindow(t *testing.T) {
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.URL.Path != "/api/v1/query_range" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = io.WriteString(w, `{"status":"error","error":"timeout exceeded during query execution: 30.000 seconds"}`)
+	}))
+	defer srv.Close()
+
+	service := NewExportService(t.TempDir(), "test")
+	cfg := domain.ExportConfig{
+		Connection: domain.VMConnection{URL: srv.URL},
+		TimeRange: domain.TimeRange{
+			Start: time.Unix(0, 0),
+			End:   time.Unix(60, 0),
+		},
+		Mode:      domain.ExportModeCustom,
+		QueryType: domain.QueryModeMetricsQL,
+		Query:     `rate(vm_rows_inserted_total[5m])`,
+		Batching:  domain.BatchSettings{Enabled: false, Strategy: "manual"},
+		Safety: domain.ExportSafetyConfig{
+			AutoSplit:        true,
+			SplitByJob:       true,
+			MinWindowSeconds: 5,
+			MaxSplitDepth:    8,
+		},
+	}
+	ApplyExportDefaults(&cfg)
+
+	_, err := service.ExecuteExport(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected timeout failure")
+	}
+	if !strings.Contains(err.Error(), "-search.maxQueryDuration") {
+		t.Fatalf("expected actionable timeout error, got %v", err)
+	}
+	if requests == 0 || requests > 64 {
+		t.Fatalf("expected bounded retry count, got %d", requests)
+	}
+}
+
+func TestAdaptiveRetryDoesNotAppendFailedPartialAttempt(t *testing.T) {
+	start := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+	var largeAttemptFailed bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/query_range" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		startSecs, _ := strconv.ParseInt(r.URL.Query().Get("start"), 10, 64)
+		endSecs, _ := strconv.ParseInt(r.URL.Query().Get("end"), 10, 64)
+		rangeStart := time.Unix(startSecs, 0)
+		rangeEnd := time.Unix(endSecs, 0)
+		duration := rangeEnd.Sub(rangeStart)
+		if duration == time.Hour && !largeAttemptFailed && rangeStart.Equal(start) {
+			largeAttemptFailed = true
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "success",
+				"data": map[string]any{
+					"resultType": "matrix",
+					"result": []any{
+						map[string]any{
+							"metric": map[string]string{
+								"__name__": "vm_rows_inserted_total",
+								"job":      "vmagent",
+							},
+							"values": [][]any{{float64(rangeStart.Unix()), "1"}},
+						},
+					},
+				},
+			})
+			return
+		}
+		if duration >= 2*time.Hour || (duration == time.Hour && rangeStart.Equal(start.Add(time.Hour))) {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = io.WriteString(w, `{"status":"error","error":"timeout exceeded during query execution: 30.000 seconds"}`)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": "success",
+			"data": map[string]any{
+				"resultType": "matrix",
+				"result": []any{
+					map[string]any{
+						"metric": map[string]string{
+							"__name__": "vm_rows_inserted_total",
+							"job":      "vmagent",
+						},
+						"values": [][]any{{float64(rangeStart.Unix()), "1"}},
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	outputDir := t.TempDir()
+	service := NewExportService(outputDir, "test")
+	cfg := domain.ExportConfig{
+		Connection: domain.VMConnection{URL: srv.URL},
+		TimeRange: domain.TimeRange{
+			Start: start,
+			End:   start.Add(2 * time.Hour),
+		},
+		Mode:      domain.ExportModeCustom,
+		QueryType: domain.QueryModeMetricsQL,
+		Query:     `rate(vm_rows_inserted_total[5m])`,
+		Batching:  domain.BatchSettings{Enabled: false, Strategy: "manual"},
+	}
+	ApplyExportDefaults(&cfg)
+
+	result, err := service.ExecuteExport(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("ExecuteExport failed: %v", err)
+	}
+
+	archiveReader, err := zip.OpenReader(result.ArchivePath)
+	if err != nil {
+		t.Fatalf("failed to open archive: %v", err)
+	}
+	defer func() { _ = archiveReader.Close() }()
+
+	lines := 0
+	for _, file := range archiveReader.File {
+		if file.Name != "metrics.jsonl" {
+			continue
+		}
+		rc, err := file.Open()
+		if err != nil {
+			t.Fatalf("failed to open metrics.jsonl: %v", err)
+		}
+		data, err := io.ReadAll(rc)
+		_ = rc.Close()
+		if err != nil {
+			t.Fatalf("failed to read metrics.jsonl: %v", err)
+		}
+		lines = len(strings.Split(strings.TrimSpace(string(data)), "\n"))
+	}
+	if lines != 3 {
+		t.Fatalf("expected only successful split output in archive, got %d lines", lines)
+	}
 }

--- a/internal/application/services/export_service_chunking_test.go
+++ b/internal/application/services/export_service_chunking_test.go
@@ -110,7 +110,9 @@ func TestQueryRangeTimeoutSplitsTimeWindow(t *testing.T) {
 	var requests []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v1/query_range" {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			http.NotFound(w, r)
+			return
 		}
 		startRaw := r.URL.Query().Get("start")
 		endRaw := r.URL.Query().Get("end")

--- a/internal/application/services/export_service_test.go
+++ b/internal/application/services/export_service_test.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -170,26 +172,35 @@ func TestExportService_BuildExportQuery(t *testing.T) {
 
 func TestCustomSelectorWithSelectedJobsUsesExportAPIWhenSelectorCanBeRewritten(t *testing.T) {
 	exportBody := `{"metric":{"__name__":"vm_app_version","job":"a","env":"prod"},"values":[1],"timestamps":[1]}` + "\n"
+	handlerErrs := make(chan error, 4)
+	reportHandlerErr := func(format string, args ...any) {
+		handlerErrs <- fmt.Errorf(format, args...)
+	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/v1/export":
 			if err := r.ParseForm(); err != nil {
-				t.Fatalf("parse form failed: %v", err)
+				reportHandlerErr("parse form failed: %v", err)
+				return
 			}
 			matchers := r.Form["match[]"]
 			if len(matchers) != 1 {
-				t.Fatalf("expected one matcher, got %v", matchers)
+				reportHandlerErr("expected one matcher, got %v", matchers)
+				return
 			}
 			expected := `vm_app_version{env="prod",job=~"a|b"}`
 			if matchers[0] != expected {
-				t.Fatalf("unexpected export matcher %q, want %q", matchers[0], expected)
+				reportHandlerErr("unexpected export matcher %q, want %q", matchers[0], expected)
+				return
 			}
 			w.Header().Set("Content-Type", "application/x-json-stream")
 			_, _ = io.WriteString(w, exportBody)
 		case "/api/v1/query_range":
-			t.Fatalf("query_range must not be used for rewritable selector")
+			reportHandlerErr("query_range must not be used for rewritable selector")
+			http.Error(w, "unexpected query_range", http.StatusInternalServerError)
 		default:
-			t.Fatalf("unexpected path: %s", r.URL.Path)
+			reportHandlerErr("unexpected path: %s", r.URL.Path)
+			http.NotFound(w, r)
 		}
 	}))
 	defer srv.Close()
@@ -214,6 +225,11 @@ func TestCustomSelectorWithSelectedJobsUsesExportAPIWhenSelectorCanBeRewritten(t
 	}
 	if count != 1 {
 		t.Fatalf("expected 1 metric, got %d", count)
+	}
+	select {
+	case handlerErr := <-handlerErrs:
+		t.Fatal(handlerErr)
+	default:
 	}
 }
 
@@ -843,6 +859,75 @@ func TestTooManySeriesSplitsByJobAndCompletes(t *testing.T) {
 	}
 	if result.MetricsExported != 2 {
 		t.Fatalf("expected 2 metrics after job split, got %d", result.MetricsExported)
+	}
+}
+
+func TestSplitByJobFailureDoesNotAppendPartialSubSplit(t *testing.T) {
+	var mu sync.Mutex
+	requests := make([]string, 0, 3)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/export" {
+			http.NotFound(w, r)
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		matcher := ""
+		if values := r.Form["match[]"]; len(values) > 0 {
+			matcher = values[0]
+		}
+		mu.Lock()
+		requests = append(requests, matcher)
+		mu.Unlock()
+		switch matcher {
+		case `{job=~"a|b"}`:
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = io.WriteString(w, `the number of matching timeseries exceeds 10000000`)
+		case `{job=~"a"}`:
+			_, _ = io.WriteString(w, `{"metric":{"__name__":"vm_app_version","job":"a"},"values":[1],"timestamps":[1]}`+"\n")
+		case `{job=~"b"}`:
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = io.WriteString(w, `bad request`)
+		default:
+			http.Error(w, fmt.Sprintf("unexpected matcher: %q", matcher), http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	outputDir := t.TempDir()
+	stagingFile := filepath.Join(outputDir, "failed-split.partial.jsonl")
+	service := NewExportService(outputDir, "test-version")
+	cfg := domain.ExportConfig{
+		Connection: domain.VMConnection{URL: server.URL},
+		TimeRange: domain.TimeRange{
+			Start: time.Unix(0, 0),
+			End:   time.Unix(60, 0),
+		},
+		Mode:        domain.ExportModeCluster,
+		Jobs:        []string{"a", "b"},
+		Batching:    domain.BatchSettings{Enabled: false, Strategy: "manual"},
+		StagingDir:  outputDir,
+		StagingFile: stagingFile,
+	}
+	ApplyExportDefaults(&cfg)
+
+	_, err := service.ExecuteExport(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected split failure")
+	}
+	data, readErr := os.ReadFile(stagingFile)
+	if readErr != nil {
+		t.Fatalf("failed to read staging file: %v", readErr)
+	}
+	if strings.TrimSpace(string(data)) != "" {
+		t.Fatalf("expected failed split to leave main staging empty, got %s", string(data))
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if got := strings.Join(requests, ","); got != `{job=~"a|b"},{job=~"a"},{job=~"b"}` {
+		t.Fatalf("unexpected request sequence: %v", requests)
 	}
 }
 

--- a/internal/application/services/export_service_test.go
+++ b/internal/application/services/export_service_test.go
@@ -140,8 +140,8 @@ func TestExportService_BuildExportQuery(t *testing.T) {
 				Query:     `{__name__=~"vm_.*"}`,
 				Jobs:      []string{"vmstorage-prod", "vmselect-prod"},
 			},
-			expected:    `({__name__=~"vm_.*"}) and on(job) {job=~"vmstorage-prod|vmselect-prod"}`,
-			useQueryRng: true,
+			expected:    `{__name__=~"vm_.*",job=~"vmstorage-prod|vmselect-prod"}`,
+			useQueryRng: false,
 		},
 		{
 			name: "custom metricsql forces query_range",
@@ -165,6 +165,55 @@ func TestExportService_BuildExportQuery(t *testing.T) {
 				t.Fatalf("useQueryRange = %v, want %v", useQueryRange, tt.useQueryRng)
 			}
 		})
+	}
+}
+
+func TestCustomSelectorWithSelectedJobsUsesExportAPIWhenSelectorCanBeRewritten(t *testing.T) {
+	exportBody := `{"metric":{"__name__":"vm_app_version","job":"a","env":"prod"},"values":[1],"timestamps":[1]}` + "\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/export":
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("parse form failed: %v", err)
+			}
+			matchers := r.Form["match[]"]
+			if len(matchers) != 1 {
+				t.Fatalf("expected one matcher, got %v", matchers)
+			}
+			expected := `vm_app_version{env="prod",job=~"a|b"}`
+			if matchers[0] != expected {
+				t.Fatalf("unexpected export matcher %q, want %q", matchers[0], expected)
+			}
+			w.Header().Set("Content-Type", "application/x-json-stream")
+			_, _ = io.WriteString(w, exportBody)
+		case "/api/v1/query_range":
+			t.Fatalf("query_range must not be used for rewritable selector")
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	cfg := domain.ExportConfig{
+		Connection: domain.VMConnection{URL: srv.URL},
+		TimeRange: domain.TimeRange{
+			Start: time.Now().Add(-time.Minute),
+			End:   time.Now(),
+		},
+		Mode:      domain.ExportModeCustom,
+		QueryType: domain.QueryModeSelector,
+		Query:     `vm_app_version{env="prod"}`,
+		Jobs:      []string{"a", "b"},
+		Batching:  domain.BatchSettings{Enabled: false},
+	}
+
+	var buf bytes.Buffer
+	count, err := ExportToWriter(context.Background(), cfg, &buf)
+	if err != nil {
+		t.Fatalf("export failed: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 metric, got %d", count)
 	}
 }
 
@@ -740,6 +789,60 @@ func TestExportService_ExecuteExportStreamsWithoutPrematureCancellation(t *testi
 		}
 	case <-time.After(timeout):
 		t.Fatal("server never finished writing export payload")
+	}
+}
+
+func TestTooManySeriesSplitsByJobAndCompletes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/export":
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("parse form failed: %v", err)
+			}
+			matcher := ""
+			if values := r.Form["match[]"]; len(values) > 0 {
+				matcher = values[0]
+			}
+			switch matcher {
+			case `{job=~"a|b"}`:
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = io.WriteString(w, `the number of matching timeseries exceeds 10000000`)
+			case `{job=~"a"}`:
+				_, _ = io.WriteString(w, `{"metric":{"__name__":"vm_app_version","job":"a"},"values":[1],"timestamps":[1]}`+"\n")
+			case `{job=~"b"}`:
+				_, _ = io.WriteString(w, `{"metric":{"__name__":"vm_app_version","job":"b"},"values":[1],"timestamps":[1]}`+"\n")
+			default:
+				t.Fatalf("unexpected matcher: %q", matcher)
+			}
+		case "/api/v1/query_range":
+			t.Fatalf("query_range must not be used for job split export")
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	outputDir := t.TempDir()
+	service := NewExportService(outputDir, "test-version")
+	cfg := domain.ExportConfig{
+		Connection: domain.VMConnection{URL: server.URL},
+		TimeRange: domain.TimeRange{
+			Start: time.Unix(0, 0),
+			End:   time.Unix(60, 0),
+		},
+		Mode:       domain.ExportModeCluster,
+		Jobs:       []string{"a", "b"},
+		Batching:   domain.BatchSettings{Enabled: false, Strategy: "manual"},
+		StagingDir: outputDir,
+	}
+	ApplyExportDefaults(&cfg)
+
+	result, err := service.ExecuteExport(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("ExecuteExport failed: %v", err)
+	}
+	if result.MetricsExported != 2 {
+		t.Fatalf("expected 2 metrics after job split, got %d", result.MetricsExported)
 	}
 }
 

--- a/internal/application/services/export_service_test.go
+++ b/internal/application/services/export_service_test.go
@@ -862,6 +862,65 @@ func TestTooManySeriesSplitsByJobAndCompletes(t *testing.T) {
 	}
 }
 
+func TestMissingRouteFallsBackToQueryRangeWhenAdaptivityOff(t *testing.T) {
+	var requests []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.URL.Path)
+		switch r.URL.Path {
+		case "/api/v1/export":
+			w.WriteHeader(http.StatusNotFound)
+		case "/api/v1/query_range":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "success",
+				"data": map[string]any{
+					"resultType": "matrix",
+					"result": []any{
+						map[string]any{
+							"metric": map[string]string{
+								"__name__": "vm_app_version",
+								"job":      "vmagent",
+							},
+							"values": [][]any{{float64(1700000000), "1"}},
+						},
+					},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	outputDir := t.TempDir()
+	service := NewExportService(outputDir, "test-version")
+	cfg := domain.ExportConfig{
+		Connection: domain.VMConnection{URL: server.URL},
+		TimeRange: domain.TimeRange{
+			Start: time.Unix(0, 0),
+			End:   time.Unix(60, 0),
+		},
+		Mode:       domain.ExportModeCluster,
+		Jobs:       []string{"vmagent"},
+		Batching:   domain.BatchSettings{Enabled: false, Strategy: "manual"},
+		StagingDir: outputDir,
+		Safety: domain.ExportSafetyConfig{
+			Mode: domain.ExportAdaptivityOff,
+		},
+	}
+	ApplyExportDefaults(&cfg)
+
+	result, err := service.ExecuteExport(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("ExecuteExport failed: %v", err)
+	}
+	if result.MetricsExported != 1 {
+		t.Fatalf("expected 1 exported metric, got %d", result.MetricsExported)
+	}
+	if got := strings.Join(requests, ","); got != "/api/v1/export,/api/v1/query_range" {
+		t.Fatalf("unexpected request sequence: %v", requests)
+	}
+}
+
 func TestSplitByJobFailureDoesNotAppendPartialSubSplit(t *testing.T) {
 	var mu sync.Mutex
 	requests := make([]string, 0, 3)

--- a/internal/application/services/export_service_test.go
+++ b/internal/application/services/export_service_test.go
@@ -413,7 +413,7 @@ func TestExportService_BuildArchiveMetadata(t *testing.T) {
 		},
 	}
 
-	metadata := service.buildArchiveMetadata("test-export", config, 1500, obfuscationMaps)
+	metadata := service.buildArchiveMetadata("test-export", config, 1500, obfuscationMaps, nil)
 
 	// Verify fields
 	if metadata.ExportID != "test-export" {

--- a/internal/application/services/oneshot_export_test.go
+++ b/internal/application/services/oneshot_export_test.go
@@ -135,8 +135,30 @@ func TestOneshotExport_Positive_SelectorNoJobFilter(t *testing.T) {
 }
 
 func TestOneshotExport_Positive_SelectorWithJobFilter(t *testing.T) {
-	exportBody := `{"metric":{"__name__":"vm_app_version","job":"test1"},"values":[1],"timestamps":[1]}` + "\n"
-	srv := serveExportAndQueryRange(t, http.StatusOK, exportBody, http.StatusOK, "")
+	exportBody := `{"metric":{"__name__":"vm_app_version","job":"test1","env":"prod"},"values":[1],"timestamps":[1]}` + "\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/export":
+			if err := r.ParseForm(); err != nil {
+				t.Errorf("parse form failed: %v", err)
+				return
+			}
+			matchers := r.Form["match[]"]
+			expected := `vm_app_version{env="prod",job=~"test1"}`
+			if len(matchers) != 1 || matchers[0] != expected {
+				t.Errorf("unexpected export matcher %v, want %q", matchers, expected)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, exportBody)
+		case "/api/v1/query_range":
+			t.Errorf("query_range must not be used for rewritable selector")
+			http.Error(w, "unexpected query_range", http.StatusInternalServerError)
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
 	defer srv.Close()
 
 	cfg := baseOneshotConfig(srv.URL)
@@ -153,6 +175,9 @@ func TestOneshotExport_Positive_SelectorWithJobFilter(t *testing.T) {
 	}
 	if !strings.Contains(out, "\"job\":\"test1\"") {
 		t.Fatalf("expected selector output: %s", out)
+	}
+	if !strings.Contains(out, "\"env\":\"prod\"") {
+		t.Fatalf("expected selector output to satisfy env matcher: %s", out)
 	}
 }
 

--- a/internal/application/services/oneshot_export_test.go
+++ b/internal/application/services/oneshot_export_test.go
@@ -211,7 +211,17 @@ func TestOneshotExport_Negative_SelectorExportFails(t *testing.T) {
 }
 
 func TestOneshotExport_Negative_SelectorJobFilterQueryRangeFails(t *testing.T) {
-	srv := serveExportAndQueryRange(t, http.StatusBadRequest, "bad request", http.StatusBadRequest, "bad request")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/export":
+			t.Fatalf("export API must not be used for selector query requiring query_range")
+		case "/api/v1/query_range":
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = io.WriteString(w, "bad request")
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
 	defer srv.Close()
 
 	cfg := baseOneshotConfig(srv.URL)

--- a/internal/application/services/oneshot_export_test.go
+++ b/internal/application/services/oneshot_export_test.go
@@ -135,14 +135,14 @@ func TestOneshotExport_Positive_SelectorNoJobFilter(t *testing.T) {
 }
 
 func TestOneshotExport_Positive_SelectorWithJobFilter(t *testing.T) {
-	queryBody := `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"vm_app_version","job":"test1"},"values":[[1700000000,"1"]]}]}}`
-	srv := serveExportAndQueryRange(t, http.StatusOK, "", http.StatusOK, queryBody)
+	exportBody := `{"metric":{"__name__":"vm_app_version","job":"test1"},"values":[1],"timestamps":[1]}` + "\n"
+	srv := serveExportAndQueryRange(t, http.StatusOK, exportBody, http.StatusOK, "")
 	defer srv.Close()
 
 	cfg := baseOneshotConfig(srv.URL)
 	cfg.Mode = domain.ExportModeCustom
 	cfg.QueryType = domain.QueryModeSelector
-	cfg.Query = `{job=~"test.*"}`
+	cfg.Query = `vm_app_version{env="prod"}`
 	cfg.Jobs = []string{"test1"}
 	out, count, err := runExportToWriter(t, cfg)
 	if err != nil {
@@ -211,16 +211,16 @@ func TestOneshotExport_Negative_SelectorExportFails(t *testing.T) {
 }
 
 func TestOneshotExport_Negative_SelectorJobFilterQueryRangeFails(t *testing.T) {
-	srv := serveExportAndQueryRange(t, http.StatusOK, "", http.StatusBadRequest, "bad request")
+	srv := serveExportAndQueryRange(t, http.StatusBadRequest, "bad request", http.StatusBadRequest, "bad request")
 	defer srv.Close()
 
 	cfg := baseOneshotConfig(srv.URL)
 	cfg.Mode = domain.ExportModeCustom
 	cfg.QueryType = domain.QueryModeSelector
-	cfg.Query = `{job=~"test.*"}`
+	cfg.Query = `sum(rate({job=~"test.*"}[5m]))`
 	cfg.Jobs = []string{"test1"}
 	_, _, err := runExportToWriter(t, cfg)
 	if err == nil {
-		t.Fatalf("expected selector query_range failure")
+		t.Fatalf("expected selector query failure")
 	}
 }

--- a/internal/application/services/oneshot_export_test.go
+++ b/internal/application/services/oneshot_export_test.go
@@ -239,12 +239,16 @@ func TestOneshotExport_Negative_SelectorJobFilterQueryRangeFails(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/v1/export":
-			t.Fatalf("export API must not be used for selector query requiring query_range")
+			t.Errorf("export API must not be used for selector query requiring query_range")
+			http.Error(w, "unexpected export api usage", http.StatusInternalServerError)
+			return
 		case "/api/v1/query_range":
 			w.WriteHeader(http.StatusBadRequest)
 			_, _ = io.WriteString(w, "bad request")
 		default:
-			t.Fatalf("unexpected path: %s", r.URL.Path)
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			http.NotFound(w, r)
+			return
 		}
 	}))
 	defer srv.Close()

--- a/internal/application/services/progress.go
+++ b/internal/application/services/progress.go
@@ -22,10 +22,11 @@ type BatchProgress struct {
 
 // AdaptiveRetryProgress describes an adaptive retry or split decision for the current batch.
 type AdaptiveRetryProgress struct {
-	Retries   int
-	TimeRange domain.TimeRange
-	ErrorKind string
-	Strategy  string
+	Retries     int
+	TimeRange   domain.TimeRange
+	ErrorKind   string
+	Strategy    string
+	StepSeconds int
 }
 
 // ProgressReporter receives progress events for long-running exports.

--- a/internal/application/services/progress.go
+++ b/internal/application/services/progress.go
@@ -20,9 +20,18 @@ type BatchProgress struct {
 	Duration     time.Duration
 }
 
+// AdaptiveRetryProgress describes an adaptive retry or split decision for the current batch.
+type AdaptiveRetryProgress struct {
+	Retries   int
+	TimeRange domain.TimeRange
+	ErrorKind string
+	Strategy  string
+}
+
 // ProgressReporter receives progress events for long-running exports.
 type ProgressReporter interface {
 	OnBatchComplete(BatchProgress)
+	OnAdaptiveRetry(AdaptiveRetryProgress)
 }
 
 // WithProgressReporter attaches a reporter to the context so that ExecuteExport can publish progress.
@@ -41,5 +50,12 @@ func getProgressReporter(ctx context.Context) ProgressReporter {
 func ReportBatchProgress(ctx context.Context, progress BatchProgress) {
 	if reporter := getProgressReporter(ctx); reporter != nil {
 		reporter.OnBatchComplete(progress)
+	}
+}
+
+// ReportAdaptiveRetry delivers adaptive retry updates to the reporter stored in the context.
+func ReportAdaptiveRetry(ctx context.Context, progress AdaptiveRetryProgress) {
+	if reporter := getProgressReporter(ctx); reporter != nil {
+		reporter.OnAdaptiveRetry(progress)
 	}
 }

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -34,6 +34,15 @@ const (
 	QueryModeMetricsQL QueryMode = "metricsql"
 )
 
+// ExportAdaptivityMode controls how aggressively vmgather changes export plans after VM rejects heavy reads.
+type ExportAdaptivityMode string
+
+const (
+	ExportAdaptivityOff       ExportAdaptivityMode = "off"
+	ExportAdaptivitySafe      ExportAdaptivityMode = "safe"
+	ExportAdaptivityAutopilot ExportAdaptivityMode = "autopilot"
+)
+
 // AuthConfig contains authentication settings
 type AuthConfig struct {
 	Type        AuthType `json:"type"`
@@ -81,11 +90,14 @@ type BatchSettings struct {
 
 // ExportSafetyConfig controls adaptive retries when VictoriaMetrics rejects heavy reads.
 type ExportSafetyConfig struct {
-	AutoSplit         bool `json:"auto_split"`
-	SplitByJob        bool `json:"split_by_job"`
-	SplitByMetricName bool `json:"split_by_metric_name,omitempty"`
-	MinWindowSeconds  int  `json:"min_window_seconds,omitempty"`
-	MaxSplitDepth     int  `json:"max_split_depth,omitempty"`
+	Mode              ExportAdaptivityMode `json:"mode,omitempty"`
+	AutoSplit         bool                 `json:"auto_split"`
+	SplitByJob        bool                 `json:"split_by_job"`
+	SplitByMetricName bool                 `json:"split_by_metric_name,omitempty"`
+	MinWindowSeconds  int                  `json:"min_window_seconds,omitempty"`
+	MaxSplitDepth     int                  `json:"max_split_depth,omitempty"`
+	MaxStepSeconds    int                  `json:"max_step_seconds,omitempty"`
+	StepLadderSeconds []int                `json:"step_ladder_seconds,omitempty"`
 }
 
 // MetricSample represents a sample metric for preview

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -136,7 +136,7 @@ type ExportConfig struct {
 	Query             string             `json:"query,omitempty"`
 	Obfuscation       ObfuscationConfig  `json:"obfuscation"`
 	Batching          BatchSettings      `json:"batching"`
-	Safety            ExportSafetyConfig `json:"safety,omitempty"`
+	Safety            ExportSafetyConfig `json:"safety"`
 	StagingDir        string             `json:"staging_dir,omitempty"`
 	StagingFile       string             `json:"staging_file,omitempty"`
 	ResumeFromBatch   int                `json:"resume_from_batch,omitempty"`

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -79,6 +79,15 @@ type BatchSettings struct {
 	CustomIntervalSecs int    `json:"custom_interval_seconds,omitempty"`
 }
 
+// ExportSafetyConfig controls adaptive retries when VictoriaMetrics rejects heavy reads.
+type ExportSafetyConfig struct {
+	AutoSplit         bool `json:"auto_split"`
+	SplitByJob        bool `json:"split_by_job"`
+	SplitByMetricName bool `json:"split_by_metric_name,omitempty"`
+	MinWindowSeconds  int  `json:"min_window_seconds,omitempty"`
+	MaxSplitDepth     int  `json:"max_split_depth,omitempty"`
+}
+
 // MetricSample represents a sample metric for preview
 type MetricSample struct {
 	MetricName string            `json:"metric_name"`
@@ -106,20 +115,21 @@ type OutputSettings struct {
 
 // ExportConfig contains full export configuration
 type ExportConfig struct {
-	Connection        VMConnection      `json:"connection"`
-	TimeRange         TimeRange         `json:"time_range"`
-	Components        []string          `json:"components"`
-	Jobs              []string          `json:"jobs"`
-	Mode              ExportMode        `json:"mode,omitempty"`
-	QueryType         QueryMode         `json:"query_type,omitempty"`
-	Query             string            `json:"query,omitempty"`
-	Obfuscation       ObfuscationConfig `json:"obfuscation"`
-	Batching          BatchSettings     `json:"batching"`
-	StagingDir        string            `json:"staging_dir,omitempty"`
-	StagingFile       string            `json:"staging_file,omitempty"`
-	ResumeFromBatch   int               `json:"resume_from_batch,omitempty"`
-	MetricStepSeconds int               `json:"metric_step_seconds,omitempty"`
-	OutputSettings    OutputSettings    `json:"output_settings"`
+	Connection        VMConnection       `json:"connection"`
+	TimeRange         TimeRange          `json:"time_range"`
+	Components        []string           `json:"components"`
+	Jobs              []string           `json:"jobs"`
+	Mode              ExportMode         `json:"mode,omitempty"`
+	QueryType         QueryMode          `json:"query_type,omitempty"`
+	Query             string             `json:"query,omitempty"`
+	Obfuscation       ObfuscationConfig  `json:"obfuscation"`
+	Batching          BatchSettings      `json:"batching"`
+	Safety            ExportSafetyConfig `json:"safety,omitempty"`
+	StagingDir        string             `json:"staging_dir,omitempty"`
+	StagingFile       string             `json:"staging_file,omitempty"`
+	ResumeFromBatch   int                `json:"resume_from_batch,omitempty"`
+	MetricStepSeconds int                `json:"metric_step_seconds,omitempty"`
+	OutputSettings    OutputSettings     `json:"output_settings"`
 }
 
 // ExportResult represents the result of an export operation

--- a/internal/infrastructure/archive/writer.go
+++ b/internal/infrastructure/archive/writer.go
@@ -56,29 +56,46 @@ func validateExportID(exportID string) error {
 // Note: InstanceMap and JobMap are intentionally excluded from archive metadata
 // per issue #10 - mapping should not be included in the archive sent to customers
 type ArchiveMetadata struct {
-	ExportID        string            `json:"export_id"`
-	ExportDate      time.Time         `json:"export_date"`
-	TimeRange       domain.TimeRange  `json:"time_range"`
-	Components      []string          `json:"components"`
-	Jobs            []string          `json:"jobs"`
-	MetricsCount    int               `json:"metrics_count"`
-	Obfuscated      bool              `json:"obfuscated"`
-	InstanceMap     map[string]string `json:"instance_map,omitempty"` // Internal use only, not included in archive
-	JobMap          map[string]string `json:"job_map,omitempty"`      // Internal use only, not included in archive
-	VMGatherVersion string            `json:"vmgather_version"`
+	ExportID             string             `json:"export_id"`
+	ExportDate           time.Time          `json:"export_date"`
+	TimeRange            domain.TimeRange   `json:"time_range"`
+	Components           []string           `json:"components"`
+	Jobs                 []string           `json:"jobs"`
+	MetricsCount         int                `json:"metrics_count"`
+	Obfuscated           bool               `json:"obfuscated"`
+	InstanceMap          map[string]string  `json:"instance_map,omitempty"` // Internal use only, not included in archive
+	JobMap               map[string]string  `json:"job_map,omitempty"`      // Internal use only, not included in archive
+	AdaptiveMode         string             `json:"adaptive_mode,omitempty"`
+	MetricStepSeconds    int                `json:"metric_step_seconds,omitempty"`
+	MaxMetricStepSeconds int                `json:"max_metric_step_seconds,omitempty"`
+	Sampled              bool               `json:"sampled,omitempty"`
+	AdaptiveDecisions    []AdaptiveDecision `json:"adaptive_decisions,omitempty"`
+	VMGatherVersion      string             `json:"vmgather_version"`
 }
 
 // archiveMetadataPublic is the public version of metadata without obfuscation maps
 // This is what gets included in the archive sent to customers
 type archiveMetadataPublic struct {
-	ExportID        string           `json:"export_id"`
-	ExportDate      time.Time        `json:"export_date"`
-	TimeRange       domain.TimeRange `json:"time_range"`
-	Components      []string         `json:"components"`
-	Jobs            []string         `json:"jobs"`
-	MetricsCount    int              `json:"metrics_count"`
-	Obfuscated      bool             `json:"obfuscated"`
-	VMGatherVersion string           `json:"vmgather_version"`
+	ExportID             string             `json:"export_id"`
+	ExportDate           time.Time          `json:"export_date"`
+	TimeRange            domain.TimeRange   `json:"time_range"`
+	Components           []string           `json:"components"`
+	Jobs                 []string           `json:"jobs"`
+	MetricsCount         int                `json:"metrics_count"`
+	Obfuscated           bool               `json:"obfuscated"`
+	AdaptiveMode         string             `json:"adaptive_mode,omitempty"`
+	MetricStepSeconds    int                `json:"metric_step_seconds,omitempty"`
+	MaxMetricStepSeconds int                `json:"max_metric_step_seconds,omitempty"`
+	Sampled              bool               `json:"sampled,omitempty"`
+	AdaptiveDecisions    []AdaptiveDecision `json:"adaptive_decisions,omitempty"`
+	VMGatherVersion      string             `json:"vmgather_version"`
+}
+
+type AdaptiveDecision struct {
+	Strategy    string           `json:"strategy"`
+	ErrorKind   string           `json:"error_kind,omitempty"`
+	TimeRange   domain.TimeRange `json:"time_range"`
+	StepSeconds int              `json:"step_seconds,omitempty"`
 }
 
 // CreateArchive creates a ZIP archive with metrics data
@@ -163,14 +180,19 @@ func (w *Writer) addMetadataToArchive(zipWriter *zip.Writer, metadata ArchiveMet
 
 	// Create public metadata without obfuscation maps
 	publicMetadata := archiveMetadataPublic{
-		ExportID:        metadata.ExportID,
-		ExportDate:      metadata.ExportDate,
-		TimeRange:       metadata.TimeRange,
-		Components:      metadata.Components,
-		Jobs:            metadata.Jobs,
-		MetricsCount:    metadata.MetricsCount,
-		Obfuscated:      metadata.Obfuscated,
-		VMGatherVersion: metadata.VMGatherVersion,
+		ExportID:             metadata.ExportID,
+		ExportDate:           metadata.ExportDate,
+		TimeRange:            metadata.TimeRange,
+		Components:           metadata.Components,
+		Jobs:                 metadata.Jobs,
+		MetricsCount:         metadata.MetricsCount,
+		Obfuscated:           metadata.Obfuscated,
+		AdaptiveMode:         metadata.AdaptiveMode,
+		MetricStepSeconds:    metadata.MetricStepSeconds,
+		MaxMetricStepSeconds: metadata.MaxMetricStepSeconds,
+		Sampled:              metadata.Sampled,
+		AdaptiveDecisions:    metadata.AdaptiveDecisions,
+		VMGatherVersion:      metadata.VMGatherVersion,
 	}
 
 	encoder := json.NewEncoder(writer)

--- a/internal/infrastructure/vm/client.go
+++ b/internal/infrastructure/vm/client.go
@@ -208,6 +208,8 @@ func (c *Client) Export(ctx context.Context, selector string, start, end time.Ti
 	params.Set("match[]", selector)
 	params.Set("start", start.Format(time.RFC3339))
 	params.Set("end", end.Format(time.RFC3339))
+	params.Set("reduce_mem_usage", "1")
+	params.Set("max_rows_per_line", "10000")
 
 	// Build request
 	req, err := c.buildRequest(ctx, http.MethodPost, "/api/v1/export", params)
@@ -302,12 +304,26 @@ func classifyResponseError(statusCode int, body string) error {
 	trimmed := strings.TrimSpace(body)
 	lowered := strings.ToLower(trimmed)
 	if strings.Contains(lowered, "cannot parse accountid") || strings.Contains(lowered, "missing accountid") {
-		return fmt.Errorf("%w: %s", ErrMissingTenantPath, trimmed)
+		return &APIError{
+			StatusCode: statusCode,
+			Body:       trimmed,
+			Kind:       ErrorKindMissingRoute,
+			Err:        ErrMissingTenantPath,
+		}
 	}
 	if strings.Contains(lowered, "unsupported url format") && strings.Contains(lowered, "/prometheus/api") {
-		return fmt.Errorf("%w: %s", ErrMissingTenantPath, trimmed)
+		return &APIError{
+			StatusCode: statusCode,
+			Body:       trimmed,
+			Kind:       ErrorKindMissingRoute,
+			Err:        ErrMissingTenantPath,
+		}
 	}
-	return fmt.Errorf("unexpected status code %d: %s", statusCode, trimmed)
+	return &APIError{
+		StatusCode: statusCode,
+		Body:       trimmed,
+		Kind:       classifyBody(trimmed),
+	}
 }
 
 func connectionTargetForLog(conn domain.VMConnection) string {

--- a/internal/infrastructure/vm/client_error_detection_test.go
+++ b/internal/infrastructure/vm/client_error_detection_test.go
@@ -31,6 +31,9 @@ func TestQueryDetectsMissingTenantPath(t *testing.T) {
 	if !errors.Is(err, ErrMissingTenantPath) {
 		t.Fatalf("expected ErrMissingTenantPath, got %v", err)
 	}
+	if ErrorKindOf(err) != ErrorKindMissingRoute {
+		t.Fatalf("expected missing route kind, got %s", ErrorKindOf(err))
+	}
 }
 
 func TestQueryDetectsUnsupportedURLFormat(t *testing.T) {
@@ -52,5 +55,36 @@ func TestQueryDetectsUnsupportedURLFormat(t *testing.T) {
 	}
 	if !errors.Is(err, ErrMissingTenantPath) {
 		t.Fatalf("expected ErrMissingTenantPath, got %v", err)
+	}
+	if ErrorKindOf(err) != ErrorKindMissingRoute {
+		t.Fatalf("expected missing route kind, got %s", ErrorKindOf(err))
+	}
+}
+
+func TestClassifyResponseError_QueryTimeout(t *testing.T) {
+	err := classifyResponseError(http.StatusUnprocessableEntity, `{"status":"error","error":"timeout exceeded during query execution: 30.000 seconds"}`)
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected APIError, got %T", err)
+	}
+	if apiErr.Kind != ErrorKindQueryTimeout {
+		t.Fatalf("expected query timeout kind, got %s", apiErr.Kind)
+	}
+}
+
+func TestClassifyResponseError_TooManySeries(t *testing.T) {
+	err := classifyResponseError(http.StatusBadRequest, `the number of matching timeseries exceeds 10000000`)
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected APIError, got %T", err)
+	}
+	if apiErr.Kind != ErrorKindTooManySeries {
+		t.Fatalf("expected too many series kind, got %s", apiErr.Kind)
+	}
+}
+
+func TestErrorKindOf_ContextDeadlineExceededIsQueryTimeout(t *testing.T) {
+	if got := ErrorKindOf(context.DeadlineExceeded); got != ErrorKindQueryTimeout {
+		t.Fatalf("ErrorKindOf(context deadline) = %q, want %q", got, ErrorKindQueryTimeout)
 	}
 }

--- a/internal/infrastructure/vm/client_error_detection_test.go
+++ b/internal/infrastructure/vm/client_error_detection_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -80,6 +81,16 @@ func TestClassifyResponseError_TooManySeries(t *testing.T) {
 	}
 	if apiErr.Kind != ErrorKindTooManySeries {
 		t.Fatalf("expected too many series kind, got %s", apiErr.Kind)
+	}
+}
+
+func TestClassifyResponseError_Empty404KeepsStatusCode(t *testing.T) {
+	err := classifyResponseError(http.StatusNotFound, "")
+	if !strings.Contains(err.Error(), "404") {
+		t.Fatalf("expected status code in error, got %q", err.Error())
+	}
+	if got := ErrorKindOf(err); got != ErrorKindMissingRoute {
+		t.Fatalf("ErrorKindOf(empty 404) = %q, want %q", got, ErrorKindMissingRoute)
 	}
 }
 

--- a/internal/infrastructure/vm/client_error_detection_test.go
+++ b/internal/infrastructure/vm/client_error_detection_test.go
@@ -94,6 +94,13 @@ func TestClassifyResponseError_Empty404KeepsStatusCode(t *testing.T) {
 	}
 }
 
+func TestErrorKindOf_NotFoundAtStartIsMissingRoute(t *testing.T) {
+	err := errors.New("not found: /api/v1/export")
+	if got := ErrorKindOf(err); got != ErrorKindMissingRoute {
+		t.Fatalf("ErrorKindOf(not found prefix) = %q, want %q", got, ErrorKindMissingRoute)
+	}
+}
+
 func TestErrorKindOf_ContextDeadlineExceededIsQueryTimeout(t *testing.T) {
 	if got := ErrorKindOf(context.DeadlineExceeded); got != ErrorKindQueryTimeout {
 		t.Fatalf("ErrorKindOf(context deadline) = %q, want %q", got, ErrorKindQueryTimeout)

--- a/internal/infrastructure/vm/client_test.go
+++ b/internal/infrastructure/vm/client_test.go
@@ -264,16 +264,20 @@ func TestClient_Export_Success(t *testing.T) {
 			t.Errorf("unexpected method: %s", r.Method)
 		}
 		if err := r.ParseForm(); err != nil {
-			t.Fatalf("failed to parse form: %v", err)
+			t.Errorf("failed to parse form: %v", err)
+			return
 		}
 		if got := r.Form.Get("reduce_mem_usage"); got != "1" {
-			t.Fatalf("expected reduce_mem_usage=1, got %q", got)
+			t.Errorf("expected reduce_mem_usage=1, got %q", got)
+			return
 		}
 		if got := r.Form.Get("max_rows_per_line"); got != "10000" {
-			t.Fatalf("expected max_rows_per_line=10000, got %q", got)
+			t.Errorf("expected max_rows_per_line=10000, got %q", got)
+			return
 		}
 		if got := r.Form["match[]"]; len(got) != 1 || got[0] != "{__name__!=\"\"}" {
-			t.Fatalf("unexpected match selector: %v", got)
+			t.Errorf("unexpected match selector: %v", got)
+			return
 		}
 
 		// Return mock data

--- a/internal/infrastructure/vm/client_test.go
+++ b/internal/infrastructure/vm/client_test.go
@@ -263,6 +263,18 @@ func TestClient_Export_Success(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Errorf("unexpected method: %s", r.Method)
 		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("failed to parse form: %v", err)
+		}
+		if got := r.Form.Get("reduce_mem_usage"); got != "1" {
+			t.Fatalf("expected reduce_mem_usage=1, got %q", got)
+		}
+		if got := r.Form.Get("max_rows_per_line"); got != "10000" {
+			t.Fatalf("expected max_rows_per_line=10000, got %q", got)
+		}
+		if got := r.Form["match[]"]; len(got) != 1 || got[0] != "{__name__!=\"\"}" {
+			t.Fatalf("unexpected match selector: %v", got)
+		}
 
 		// Return mock data
 		w.Header().Set("Content-Type", "application/x-json-stream")

--- a/internal/infrastructure/vm/errors.go
+++ b/internal/infrastructure/vm/errors.go
@@ -28,6 +28,9 @@ type APIError struct {
 func (e *APIError) Error() string {
 	body := strings.TrimSpace(e.Body)
 	if body == "" {
+		if e.StatusCode > 0 {
+			return fmt.Sprintf("unexpected status code %d", e.StatusCode)
+		}
 		if e.Err != nil {
 			return e.Err.Error()
 		}

--- a/internal/infrastructure/vm/errors.go
+++ b/internal/infrastructure/vm/errors.go
@@ -1,0 +1,116 @@
+package vm
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+)
+
+type ErrorKind string
+
+const (
+	ErrorKindUnknown       ErrorKind = "unknown"
+	ErrorKindMissingRoute  ErrorKind = "missing_route"
+	ErrorKindQueryTimeout  ErrorKind = "query_timeout"
+	ErrorKindTooManySeries ErrorKind = "too_many_series"
+	ErrorKindTransient     ErrorKind = "transient"
+)
+
+type APIError struct {
+	StatusCode int
+	Body       string
+	Kind       ErrorKind
+	Err        error
+}
+
+func (e *APIError) Error() string {
+	body := strings.TrimSpace(e.Body)
+	if body == "" {
+		if e.Err != nil {
+			return e.Err.Error()
+		}
+		return "API request failed"
+	}
+	if e.StatusCode > 0 {
+		return fmt.Sprintf("unexpected status code %d: %s", e.StatusCode, body)
+	}
+	return body
+}
+
+func (e *APIError) Unwrap() error {
+	return e.Err
+}
+
+func ErrorKindOf(err error) ErrorKind {
+	if err == nil {
+		return ErrorKindUnknown
+	}
+	var apiErr *APIError
+	if errors.As(err, &apiErr) && apiErr.Kind != ErrorKindUnknown {
+		return apiErr.Kind
+	}
+
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "timeout exceeded during query execution"),
+		strings.Contains(msg, "timeout exceeded during the query"),
+		strings.Contains(msg, "timeout exceeded while fetching data block"),
+		strings.Contains(msg, "timeout exceeded before starting data export"),
+		strings.Contains(msg, "context deadline exceeded"):
+		return ErrorKindQueryTimeout
+	case strings.Contains(msg, "the number of matching timeseries exceeds"),
+		strings.Contains(msg, "cannot select more than -search.maxexportseries"):
+		return ErrorKindTooManySeries
+	case strings.Contains(msg, "missing route"),
+		strings.Contains(msg, "unsupported path"),
+		strings.Contains(msg, "unexpected status code 404"),
+		strings.Contains(msg, " not found"):
+		return ErrorKindMissingRoute
+	}
+
+	if isTransientError(err) {
+		return ErrorKindTransient
+	}
+
+	return ErrorKindUnknown
+}
+
+func isTransientError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "broken pipe") ||
+		strings.Contains(msg, "connection reset") ||
+		strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "unexpected eof")
+}
+
+func classifyBody(body string) ErrorKind {
+	msg := strings.ToLower(strings.TrimSpace(body))
+	switch {
+	case strings.Contains(msg, "timeout exceeded during query execution"),
+		strings.Contains(msg, "timeout exceeded during the query"),
+		strings.Contains(msg, "timeout exceeded while fetching data block"),
+		strings.Contains(msg, "timeout exceeded before starting data export"):
+		return ErrorKindQueryTimeout
+	case strings.Contains(msg, "the number of matching timeseries exceeds"),
+		strings.Contains(msg, "cannot select more than -search.maxexportseries"):
+		return ErrorKindTooManySeries
+	case strings.Contains(msg, "missing route"),
+		strings.Contains(msg, "unsupported path"),
+		strings.Contains(msg, "not found"):
+		return ErrorKindMissingRoute
+	default:
+		return ErrorKindUnknown
+	}
+}

--- a/internal/infrastructure/vm/errors.go
+++ b/internal/infrastructure/vm/errors.go
@@ -69,7 +69,7 @@ func ErrorKindOf(err error) ErrorKind {
 	case strings.Contains(msg, "missing route"),
 		strings.Contains(msg, "unsupported path"),
 		strings.Contains(msg, "unexpected status code 404"),
-		strings.Contains(msg, " not found"):
+		strings.Contains(msg, "not found"):
 		return ErrorKindMissingRoute
 	}
 

--- a/internal/server/export_jobs.go
+++ b/internal/server/export_jobs.go
@@ -42,6 +42,9 @@ type ExportJobStatus struct {
 	ETA                      *time.Time           `json:"eta,omitempty"`
 	StagingPath              string               `json:"staging_path,omitempty"`
 	ObfuscationEnabled       bool                 `json:"obfuscation_enabled"`
+	AdaptiveRetries          int                  `json:"adaptive_retries"`
+	LastErrorKind            string               `json:"last_error_kind,omitempty"`
+	CurrentStrategy          string               `json:"current_strategy,omitempty"`
 	Result                   *domain.ExportResult `json:"result,omitempty"`
 	Error                    string               `json:"error,omitempty"`
 	CurrentRange             *domain.TimeRange    `json:"current_range,omitempty"`
@@ -308,6 +311,23 @@ func (m *ExportJobManager) updateBatch(jobID string, progress services.BatchProg
 	}
 }
 
+func (m *ExportJobManager) updateAdaptiveRetry(jobID string, progress services.AdaptiveRetryProgress) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	job, exists := m.jobs[jobID]
+	if !exists {
+		return
+	}
+
+	job.status.AdaptiveRetries = progress.Retries
+	job.status.LastErrorKind = progress.ErrorKind
+	job.status.CurrentStrategy = progress.Strategy
+	job.status.CurrentRange = &domain.TimeRange{
+		Start: progress.TimeRange.Start,
+		End:   progress.TimeRange.End,
+	}
+}
+
 func (m *ExportJobManager) jobFinishedLocked() {
 	if m.activeJobs > 0 {
 		m.activeJobs--
@@ -372,4 +392,8 @@ type jobProgressReporter struct {
 
 func (r *jobProgressReporter) OnBatchComplete(progress services.BatchProgress) {
 	r.manager.updateBatch(r.jobID, progress, r.baseBatches, r.baseMetrics)
+}
+
+func (r *jobProgressReporter) OnAdaptiveRetry(progress services.AdaptiveRetryProgress) {
+	r.manager.updateAdaptiveRetry(r.jobID, progress)
 }

--- a/internal/server/export_jobs.go
+++ b/internal/server/export_jobs.go
@@ -174,6 +174,9 @@ func (m *ExportJobManager) ResumeJob(ctx context.Context, jobID string) (*Export
 	job.status.Result = nil
 	job.status.CompletedAt = nil
 	job.status.ETA = nil
+	job.status.AdaptiveRetries = 0
+	job.status.LastErrorKind = ""
+	job.status.CurrentStrategy = ""
 
 	m.activeJobs++
 

--- a/internal/server/export_jobs.go
+++ b/internal/server/export_jobs.go
@@ -45,6 +45,7 @@ type ExportJobStatus struct {
 	AdaptiveRetries          int                  `json:"adaptive_retries"`
 	LastErrorKind            string               `json:"last_error_kind,omitempty"`
 	CurrentStrategy          string               `json:"current_strategy,omitempty"`
+	CurrentStepSeconds       int                  `json:"current_step_seconds,omitempty"`
 	Result                   *domain.ExportResult `json:"result,omitempty"`
 	Error                    string               `json:"error,omitempty"`
 	CurrentRange             *domain.TimeRange    `json:"current_range,omitempty"`
@@ -177,6 +178,7 @@ func (m *ExportJobManager) ResumeJob(ctx context.Context, jobID string) (*Export
 	job.status.AdaptiveRetries = 0
 	job.status.LastErrorKind = ""
 	job.status.CurrentStrategy = ""
+	job.status.CurrentStepSeconds = 0
 
 	m.activeJobs++
 
@@ -325,6 +327,7 @@ func (m *ExportJobManager) updateAdaptiveRetry(jobID string, progress services.A
 	job.status.AdaptiveRetries = progress.Retries
 	job.status.LastErrorKind = progress.ErrorKind
 	job.status.CurrentStrategy = progress.Strategy
+	job.status.CurrentStepSeconds = progress.StepSeconds
 	job.status.CurrentRange = &domain.TimeRange{
 		Start: progress.TimeRange.Start,
 		End:   progress.TimeRange.End,

--- a/internal/server/export_jobs_test.go
+++ b/internal/server/export_jobs_test.go
@@ -12,11 +12,15 @@ import (
 
 type fakeExportService struct {
 	batches []services.BatchProgress
+	retries []services.AdaptiveRetryProgress
 	result  *domain.ExportResult
 	err     error
 }
 
 func (f *fakeExportService) ExecuteExport(ctx context.Context, config domain.ExportConfig) (*domain.ExportResult, error) {
+	for _, retry := range f.retries {
+		services.ReportAdaptiveRetry(ctx, retry)
+	}
 	for _, batch := range f.batches {
 		services.ReportBatchProgress(ctx, batch)
 		time.Sleep(5 * time.Millisecond)
@@ -97,6 +101,64 @@ func TestExportJobManagerTracksProgress(t *testing.T) {
 	}
 	if final.Progress < 0.99 {
 		t.Fatalf("progress not updated, got %.2f", final.Progress)
+	}
+}
+
+func TestExportJobStatusTracksAdaptiveRetryFields(t *testing.T) {
+	now := time.Now()
+	cfg := domain.ExportConfig{
+		TimeRange: domain.TimeRange{
+			Start: now.Add(-10 * time.Minute),
+			End:   now,
+		},
+		Batching:    domain.BatchSettings{Enabled: true},
+		StagingFile: "/tmp/job-adaptive.partial",
+	}
+
+	manager := NewExportJobManager(&fakeExportService{
+		retries: []services.AdaptiveRetryProgress{
+			{
+				Retries:   1,
+				TimeRange: cfg.TimeRange,
+				ErrorKind: "too_many_series",
+				Strategy:  "split_by_job",
+			},
+		},
+		batches: []services.BatchProgress{
+			{BatchIndex: 1, TotalBatches: 1, Metrics: 10, Duration: time.Second, TimeRange: cfg.TimeRange},
+		},
+		result: &domain.ExportResult{ExportID: "job-adaptive", MetricsExported: 10},
+	})
+
+	status, err := manager.StartJob(context.Background(), "job-adaptive", cfg)
+	if err != nil {
+		t.Fatalf("failed to start job: %v", err)
+	}
+	if status.State != JobPending {
+		t.Fatalf("expected pending job, got %s", status.State)
+	}
+
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatal("timeout waiting for adaptive retry status")
+		default:
+			s, ok := manager.GetStatus(status.ID)
+			if ok && s.State == JobCompleted {
+				if s.AdaptiveRetries != 1 {
+					t.Fatalf("expected adaptive retries=1, got %d", s.AdaptiveRetries)
+				}
+				if s.LastErrorKind != "too_many_series" {
+					t.Fatalf("expected too_many_series, got %s", s.LastErrorKind)
+				}
+				if s.CurrentStrategy != "split_by_job" {
+					t.Fatalf("expected split_by_job strategy, got %s", s.CurrentStrategy)
+				}
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
 	}
 }
 

--- a/internal/server/export_jobs_test.go
+++ b/internal/server/export_jobs_test.go
@@ -325,6 +325,9 @@ func TestResumeJobUsesSameStagingAndOffset(t *testing.T) {
 	job := manager.jobs["job-resume"]
 	job.status.CompletedBatches = 2
 	job.status.MetricsProcessed = 42
+	job.status.AdaptiveRetries = 1
+	job.status.LastErrorKind = "too_many_series"
+	job.status.CurrentStrategy = "split_by_job"
 	manager.mu.Unlock()
 
 	resumed, err := manager.ResumeJob(context.Background(), "job-resume")
@@ -333,6 +336,9 @@ func TestResumeJobUsesSameStagingAndOffset(t *testing.T) {
 	}
 	if resumed.StagingPath != cfg.StagingFile {
 		t.Fatalf("staging path lost: %s", resumed.StagingPath)
+	}
+	if resumed.AdaptiveRetries != 0 || resumed.LastErrorKind != "" || resumed.CurrentStrategy != "" {
+		t.Fatalf("adaptive retry status was not reset on resume: %+v", resumed)
 	}
 
 	deadline := time.Now().Add(200 * time.Millisecond)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -876,6 +876,7 @@ func (s *Server) handleExportStatus(w http.ResponseWriter, r *http.Request) {
 		"batch_window_seconds":        status.BatchWindowSeconds,
 		"average_batch_seconds":       status.AverageBatchSeconds,
 		"last_batch_duration_seconds": status.LastBatchDurationSeconds,
+		"adaptive_retries":            status.AdaptiveRetries,
 	}
 	if status.StagingPath != "" {
 		response["staging_path"] = status.StagingPath
@@ -892,6 +893,12 @@ func (s *Server) handleExportStatus(w http.ResponseWriter, r *http.Request) {
 	}
 	if status.Error != "" {
 		response["error"] = status.Error
+	}
+	if status.LastErrorKind != "" {
+		response["last_error_kind"] = status.LastErrorKind
+	}
+	if status.CurrentStrategy != "" {
+		response["current_strategy"] = status.CurrentStrategy
 	}
 	if status.Result != nil {
 		response["result"] = status.Result

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -877,6 +877,7 @@ func (s *Server) handleExportStatus(w http.ResponseWriter, r *http.Request) {
 		"average_batch_seconds":       status.AverageBatchSeconds,
 		"last_batch_duration_seconds": status.LastBatchDurationSeconds,
 		"adaptive_retries":            status.AdaptiveRetries,
+		"current_step_seconds":        status.CurrentStepSeconds,
 	}
 	if status.StagingPath != "" {
 		response["staging_path"] = status.StagingPath

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -669,8 +669,11 @@ func TestEnsureBatchDefaultsSetsMetricStep(t *testing.T) {
 	if cfg.MetricStepSeconds == 0 {
 		t.Fatal("expected metric step to be set automatically")
 	}
-	if cfg.MetricStepSeconds != services.RecommendedMetricStepSeconds(tr) {
-		t.Fatalf("metric step mismatch: got %d want %d", cfg.MetricStepSeconds, services.RecommendedMetricStepSeconds(tr))
+	if cfg.MetricStepSeconds != services.MinBatchIntervalSeconds {
+		t.Fatalf("metric step mismatch: got %d want %d", cfg.MetricStepSeconds, services.MinBatchIntervalSeconds)
+	}
+	if cfg.Safety.Mode != domain.ExportAdaptivityAutopilot {
+		t.Fatalf("expected autopilot safety mode, got %q", cfg.Safety.Mode)
 	}
 }
 

--- a/internal/server/static/app.js
+++ b/internal/server/static/app.js
@@ -115,6 +115,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     initializeStagingDirInput();
     initializeMetricStepSelector();
     initializeBatchWindowSelector();
+    initializeAdaptiveExportMode();
     disableCancelButton();
     wireAdvancedSummaries();
     initializeHelpSection();
@@ -1835,6 +1836,9 @@ function applyRecommendedMetricStep(forceApply) {
 }
 
 function getSelectedMetricStepSeconds() {
+    if (isAdaptiveAutopilotEnabled()) {
+        return 0;
+    }
     const select = document.getElementById('metricStep');
     if (!select) {
         return 0;
@@ -1865,6 +1869,31 @@ function initializeBatchWindowSelector() {
         customInput.addEventListener('input', updateBatchWindowHint);
     }
     syncUI();
+}
+
+function isAdaptiveAutopilotEnabled() {
+    return document.getElementById('adaptiveExportMode')?.checked !== false;
+}
+
+function syncAdaptiveExportModeUI() {
+    const manualControls = document.getElementById('exportManualControls');
+    const state = document.getElementById('adaptiveExportModeState');
+    const enabled = isAdaptiveAutopilotEnabled();
+    if (manualControls) {
+        manualControls.classList.toggle('hidden', enabled);
+    }
+    if (state) {
+        state.textContent = enabled ? 'On' : 'Off';
+    }
+}
+
+function initializeAdaptiveExportMode() {
+    const toggle = document.getElementById('adaptiveExportMode');
+    if (!toggle) {
+        return;
+    }
+    toggle.addEventListener('change', syncAdaptiveExportModeUI);
+    syncAdaptiveExportModeUI();
 }
 
 function updateBatchWindowHint() {
@@ -1898,6 +1927,13 @@ function updateBatchWindowHint() {
 }
 
 function getBatchingConfig() {
+    if (isAdaptiveAutopilotEnabled()) {
+        return {
+            enabled: true,
+            strategy: 'auto',
+            custom_interval_seconds: 0
+        };
+    }
     const select = document.getElementById('batchWindowSelect');
     const customInput = document.getElementById('customBatchWindowInput');
     let strategy = 'auto';
@@ -1923,7 +1959,7 @@ function getBatchingConfig() {
 }
 
 function getSafetyConfig() {
-    const adaptive = document.getElementById('adaptiveExportMode')?.checked !== false;
+    const adaptive = isAdaptiveAutopilotEnabled();
     return {
         mode: adaptive ? 'autopilot' : 'safe',
         auto_split: true,

--- a/internal/server/static/app.js
+++ b/internal/server/static/app.js
@@ -1922,6 +1922,16 @@ function getBatchingConfig() {
     };
 }
 
+function getSafetyConfig() {
+    const adaptive = document.getElementById('adaptiveExportMode')?.checked !== false;
+    return {
+        mode: adaptive ? 'autopilot' : 'safe',
+        auto_split: true,
+        split_by_job: true,
+        max_step_seconds: 300
+    };
+}
+
 function formatStepLabel(seconds) {
     if (!seconds || seconds < 60) {
         return `${seconds}s`;
@@ -3091,10 +3101,7 @@ async function exportMetrics(buttonElement) {
             staging_dir: stagingDirValue,
             metric_step_seconds: metricStepSeconds,
             batching: batchingConfig,
-            safety: {
-                auto_split: true,
-                split_by_job: true
-            }
+            safety: getSafetyConfig()
         };
         window.__lastExportStartPayload = exportPayload;
 
@@ -3349,12 +3356,15 @@ function updateExportProgress(status) {
         const strategyLabels = {
             split_by_job: 'Adaptive retry: split by job',
             split_by_time: 'Adaptive retry: split time window',
+            increase_step: 'Adaptive retry: lower sampling precision',
             query_range: 'Adaptive retry: switch to query_range',
             export: 'Adaptive retry: retry export plan'
         };
         if (status.current_strategy && status.adaptive_retries > 0) {
             const label = strategyLabels[status.current_strategy] || `Adaptive retry: ${status.current_strategy}`;
-            adaptiveEl.textContent = label;
+            adaptiveEl.textContent = status.current_step_seconds
+                ? `${label} (${formatStepLabel(status.current_step_seconds)})`
+                : label;
         } else {
             adaptiveEl.textContent = '';
         }

--- a/internal/server/static/app.js
+++ b/internal/server/static/app.js
@@ -3090,7 +3090,11 @@ async function exportMetrics(buttonElement) {
             obfuscation: obfuscation,
             staging_dir: stagingDirValue,
             metric_step_seconds: metricStepSeconds,
-            batching: batchingConfig
+            batching: batchingConfig,
+            safety: {
+                auto_split: true,
+                split_by_job: true
+            }
         };
         window.__lastExportStartPayload = exportPayload;
 
@@ -3260,6 +3264,7 @@ function showExportProgressPanel(meta) {
     const metrics = document.getElementById('exportProgressMetrics');
     const eta = document.getElementById('exportProgressEta');
     const windowInfo = document.getElementById('exportBatchWindow');
+    const adaptiveEl = document.getElementById('exportAdaptiveStrategy');
     const fill = document.getElementById('exportProgressFill');
 
     hideResumeExportOption();
@@ -3285,6 +3290,9 @@ function showExportProgressPanel(meta) {
     if (fill) {
         fill.style.width = '0%';
     }
+    if (adaptiveEl) {
+        adaptiveEl.textContent = '';
+    }
     if (meta.staging_path) {
         exportStagingPath = meta.staging_path;
     }
@@ -3309,6 +3317,7 @@ function updateExportProgress(status) {
     const metricsEl = document.getElementById('exportProgressMetrics');
     const etaEl = document.getElementById('exportProgressEta');
     const summaryEl = document.getElementById('exportProgressSummary');
+    const adaptiveEl = document.getElementById('exportAdaptiveStrategy');
 
     const percentage = Math.min(100, Math.round((status.progress || 0) * 100));
     if (fill) {
@@ -3335,6 +3344,20 @@ function updateExportProgress(status) {
             ? status.average_batch_seconds.toFixed(1)
             : '0.0';
         summaryEl.textContent = `Last batch ${last}s - Avg ${avg}s`;
+    }
+    if (adaptiveEl) {
+        const strategyLabels = {
+            split_by_job: 'Adaptive retry: split by job',
+            split_by_time: 'Adaptive retry: split time window',
+            query_range: 'Adaptive retry: switch to query_range',
+            export: 'Adaptive retry: retry export plan'
+        };
+        if (status.current_strategy && status.adaptive_retries > 0) {
+            const label = strategyLabels[status.current_strategy] || `Adaptive retry: ${status.current_strategy}`;
+            adaptiveEl.textContent = label;
+        } else {
+            adaptiveEl.textContent = '';
+        }
     }
     if (typeof status.obfuscation_enabled === 'boolean') {
         currentJobObfuscationEnabled = status.obfuscation_enabled;

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -1496,6 +1496,9 @@
                             <span id="exportProgressSummary"></span>
                         </div>
                         <div class="export-progress-meta">
+                            <span id="exportAdaptiveStrategy"></span>
+                        </div>
+                        <div class="export-progress-meta">
                             <span>Staging file:</span>
                             <span id="exportProgressPath" style="word-break: break-all;"></span>
                         </div>

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -525,6 +525,74 @@
             opacity: 1;
         }
 
+        .autopilot-panel {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 20px;
+            padding: 18px 20px;
+            margin-bottom: 20px;
+            border: 1px solid rgba(37, 99, 235, 0.18);
+            border-radius: 14px;
+            background: linear-gradient(135deg, rgba(37, 99, 235, 0.08), rgba(255, 255, 255, 0.96));
+        }
+
+        .autopilot-copy {
+            flex: 1;
+            min-width: 0;
+        }
+
+        .autopilot-eyebrow {
+            display: inline-flex;
+            align-items: center;
+            margin-bottom: 6px;
+            font-size: 12px;
+            font-weight: 700;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+            color: var(--primary);
+        }
+
+        .autopilot-title {
+            font-size: 18px;
+            font-weight: 700;
+            color: var(--text-main);
+        }
+
+        .autopilot-description {
+            margin-top: 4px;
+            font-size: 14px;
+            color: var(--text-muted);
+            max-width: 620px;
+        }
+
+        .autopilot-switch {
+            display: inline-flex;
+            align-items: center;
+            gap: 12px;
+            flex-shrink: 0;
+        }
+
+        .autopilot-switch .mode-slider {
+            background-color: #cbd5e1;
+        }
+
+        .autopilot-switch .mode-switch input:checked + .mode-slider {
+            background-color: var(--primary);
+        }
+
+        .autopilot-state {
+            min-width: 40px;
+            font-size: 12px;
+            font-weight: 700;
+            text-transform: uppercase;
+            color: var(--text-muted);
+        }
+
+        .manual-export-controls {
+            margin-bottom: 8px;
+        }
+
         .selector-job-item {
             padding: 10px 12px;
             border: 1px solid var(--border);
@@ -1036,6 +1104,16 @@
                 padding: 20px;
             }
 
+            .autopilot-panel {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+
+            .autopilot-switch {
+                width: 100%;
+                justify-content: space-between;
+            }
+
             header h1 {
                 font-size: 20px;
             }
@@ -1452,39 +1530,50 @@
                             so partial files survive interruptions.</span>
                     </div>
 
-                    <div class="form-row">
-                        <div class="form-group">
-                            <label for="metricStep">Metric sampling step</label>
-                            <select id="metricStep">
-                                <option value="auto">Auto (based on time range)</option>
-                                <option value="30">30 seconds</option>
-                                <option value="60">1 minute</option>
-                                <option value="300">5 minutes</option>
-                            </select>
-                            <span class="input-hint" id="metricStepHint">Recommended step: 1 min</span>
+                    <div class="autopilot-panel">
+                        <div class="autopilot-copy">
+                            <div class="autopilot-eyebrow">Export mode</div>
+                            <div class="autopilot-title">Adaptive export autopilot</div>
+                            <div class="autopilot-description">
+                                Starts at full precision and only relaxes sampling up to 5 minutes when VictoriaMetrics rejects a heavy request.
+                            </div>
                         </div>
-                        <div class="form-group">
-                            <label for="batchWindowSelect">Batch window (Auto)</label>
-                            <select id="batchWindowSelect">
-                                <option value="auto" selected>Auto (recommended)</option>
-                                <option value="300">5 minutes</option>
-                                <option value="900">15 minutes</option>
-                                <option value="3600">1 hour</option>
-                                <option value="custom">Custom...</option>
-                            </select>
-                            <input type="number" id="customBatchWindowInput" placeholder="Seconds"
-                                min="30" step="1" style="display: none; margin-top: 8px;">
-                            <span class="input-hint" id="batchWindowHint">Max duration per batch. Auto adapts to the
-                                time range.</span>
+                        <div class="autopilot-switch">
+                            <span class="autopilot-state" id="adaptiveExportModeState">On</span>
+                            <label class="mode-switch">
+                                <input type="checkbox" id="adaptiveExportMode" checked aria-label="Toggle adaptive export autopilot">
+                                <span class="mode-slider"></span>
+                            </label>
                         </div>
                     </div>
-                    <div class="form-group">
-                        <label>
-                            <input type="checkbox" id="adaptiveExportMode" checked
-                                style="width: auto; margin-right: 10px;">
-                            Adaptive export autopilot
-                        </label>
-                        <span class="input-hint">Starts with full precision and only lowers query_range sampling up to 5 minutes when VictoriaMetrics rejects the request.</span>
+
+                    <div id="exportManualControls" class="manual-export-controls hidden">
+                        <div class="form-row">
+                            <div class="form-group">
+                                <label for="metricStep">Metric sampling step</label>
+                                <select id="metricStep">
+                                    <option value="auto">Auto (based on time range)</option>
+                                    <option value="30">30 seconds</option>
+                                    <option value="60">1 minute</option>
+                                    <option value="300">5 minutes</option>
+                                </select>
+                                <span class="input-hint" id="metricStepHint">Recommended step: 1 min</span>
+                            </div>
+                            <div class="form-group">
+                                <label for="batchWindowSelect">Batch window</label>
+                                <select id="batchWindowSelect">
+                                    <option value="auto" selected>Auto (recommended)</option>
+                                    <option value="300">5 minutes</option>
+                                    <option value="900">15 minutes</option>
+                                    <option value="3600">1 hour</option>
+                                    <option value="custom">Custom...</option>
+                                </select>
+                                <input type="number" id="customBatchWindowInput" placeholder="Seconds"
+                                    min="30" step="1" style="display: none; margin-top: 8px;">
+                                <span class="input-hint" id="batchWindowHint">Max duration per batch. Auto adapts to the
+                                    time range.</span>
+                            </div>
+                        </div>
                     </div>
 
                     <div id="exportProgressPanel" class="export-progress hidden">

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -1478,6 +1478,14 @@
                                 time range.</span>
                         </div>
                     </div>
+                    <div class="form-group">
+                        <label>
+                            <input type="checkbox" id="adaptiveExportMode" checked
+                                style="width: auto; margin-right: 10px;">
+                            Adaptive export autopilot
+                        </label>
+                        <span class="input-hint">Starts with full precision and only lowers query_range sampling up to 5 minutes when VictoriaMetrics rejects the request.</span>
+                    </div>
 
                     <div id="exportProgressPanel" class="export-progress hidden">
                         <div class="export-progress-header">

--- a/tests/e2e/specs/export-progress.spec.js
+++ b/tests/e2e/specs/export-progress.spec.js
@@ -136,7 +136,8 @@ test.beforeEach(async ({ page }) => {
   });
 });
 
-async function goToObfuscationStep(page) {
+async function goToObfuscationStep(page, options = {}) {
+  const { manualTuning = false } = options;
   await page.goto('/');
   await page.waitForLoadState('networkidle');
   await page.locator('button:has-text("Next")').first().click();
@@ -161,8 +162,23 @@ async function goToObfuscationStep(page) {
   await page.locator('#stagingDir').blur();
   await page.evaluate(() => window.validateStagingDir && window.validateStagingDir(true));
   await waitForHintText(page, 'Ready');
-  await page.selectOption('#metricStep', '60');
-  await page.selectOption('#batchWindowSelect', '300');
+  if (manualTuning) {
+    await setAdaptiveExportMode(page, false);
+    await expect(page.locator('#exportManualControls')).toBeVisible();
+    await page.selectOption('#metricStep', '60');
+    await page.selectOption('#batchWindowSelect', '300');
+  }
+}
+
+async function setAdaptiveExportMode(page, enabled) {
+  await page.evaluate((nextValue) => {
+    const input = document.getElementById('adaptiveExportMode');
+    if (!input) {
+      throw new Error('adaptiveExportMode input not found');
+    }
+    input.checked = nextValue;
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+  }, enabled);
 }
 
 test.describe('Export progress UI', () => {
@@ -172,7 +188,7 @@ test.describe('Export progress UI', () => {
       expect(requestBody.staging_dir).toBe(STAGING_DIR);
       expect(requestBody.metric_step_seconds).toBe(60);
       expect(requestBody.safety).toMatchObject({
-        mode: 'autopilot',
+        mode: 'safe',
         auto_split: true,
         split_by_job: true,
         max_step_seconds: 300,
@@ -236,7 +252,7 @@ test.describe('Export progress UI', () => {
       });
     });
 
-    await goToObfuscationStep(page);
+    await goToObfuscationStep(page, { manualTuning: true });
     const progressPanel = page.locator('#exportProgressPanel');
     await expect(progressPanel).toHaveClass(/hidden/);
 
@@ -250,13 +266,92 @@ test.describe('Export progress UI', () => {
     await page.waitForFunction(() => window.__lastExportStartPayload || window.__lastExportError);
     const exportError = await page.evaluate(() => window.__lastExportError);
     expect(exportError).toBeFalsy();
-    await expect(page.locator('#exportProgressPath')).toContainText(STAGING_DIR);
     await expect(page.locator('#exportProgressPercent')).toContainText('0%');
     await expect(page.locator('#exportBatchWindow')).toContainText('≈ 60s');
 
     await page.waitForSelector('.step[data-step="7"]');
     await expect(page.locator('#exportProgressPercent')).toContainText('100%');
     await expect(page.locator('#exportSpoilers')).toContainText('777.777.1.1:8428');
+  });
+
+  test('autopilot hides manual tuning until disabled', async ({ page }) => {
+    let exportPayload;
+
+    await page.route('**/api/export/start', route => {
+      exportPayload = route.request().postDataJSON();
+      route.fulfill({
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          job_id: 'job-autopilot-ui-test',
+          total_batches: 1,
+          batch_window_seconds: 60,
+          staging_path: STAGING_DIR,
+        }),
+      });
+    });
+
+    await page.route('**/api/export/status**', route => {
+      route.fulfill({
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          job_id: 'job-autopilot-ui-test',
+          state: 'completed',
+          total_batches: 1,
+          completed_batches: 1,
+          progress: 1,
+          metrics_processed: 100,
+          batch_window_seconds: 60,
+          staging_path: STAGING_DIR,
+          result: {
+            export_id: 'job-autopilot-ui-test',
+            archive_path: '/tmp/export.zip',
+            archive_size: 512,
+            metrics_count: 100,
+            sha256: 'sha256sum',
+            obfuscation_applied: true,
+            sample_data: [],
+          },
+        }),
+      });
+    });
+
+    await goToObfuscationStep(page);
+    await expect(page.locator('#adaptiveExportMode')).toBeChecked();
+    await expect(page.locator('#adaptiveExportModeState')).toHaveText('On');
+    await expect(page.locator('#exportManualControls')).toBeHidden();
+
+    await setAdaptiveExportMode(page, false);
+    await expect(page.locator('#adaptiveExportModeState')).toHaveText('Off');
+    await expect(page.locator('#exportManualControls')).toBeVisible();
+    await page.selectOption('#metricStep', '60');
+    await page.selectOption('#batchWindowSelect', '300');
+
+    await setAdaptiveExportMode(page, true);
+    await expect(page.locator('#adaptiveExportModeState')).toHaveText('On');
+    await expect(page.locator('#exportManualControls')).toBeHidden();
+
+    await page.waitForSelector('.step[data-step="6"].active #startExportBtn:enabled');
+    await page.evaluate(() => {
+      const btn = document.getElementById('startExportBtn');
+      if (btn && window.exportMetrics) {
+        window.exportMetrics(btn);
+      }
+    });
+
+    await expect.poll(() => exportPayload).toBeTruthy();
+    expect(exportPayload.metric_step_seconds).toBe(0);
+    expect(exportPayload.batching).toMatchObject({
+      strategy: 'auto',
+      custom_interval_seconds: 0,
+    });
+    expect(exportPayload.safety).toMatchObject({
+      mode: 'autopilot',
+      auto_split: true,
+      split_by_job: true,
+      max_step_seconds: 300,
+    });
   });
 
   test('shows adaptive retry state during export', async ({ page }) => {

--- a/tests/e2e/specs/export-progress.spec.js
+++ b/tests/e2e/specs/export-progress.spec.js
@@ -172,8 +172,10 @@ test.describe('Export progress UI', () => {
       expect(requestBody.staging_dir).toBe(STAGING_DIR);
       expect(requestBody.metric_step_seconds).toBe(60);
       expect(requestBody.safety).toMatchObject({
+        mode: 'autopilot',
         auto_split: true,
         split_by_job: true,
+        max_step_seconds: 300,
       });
       expect(requestBody.batching).toMatchObject({
         strategy: 'custom',
@@ -289,6 +291,7 @@ test.describe('Export progress UI', () => {
           staging_path: STAGING_DIR,
           adaptive_retries: 1,
           current_strategy: 'split_by_job',
+          current_step_seconds: 30,
           last_error_kind: 'too_many_series',
           result: {
             export_id: 'job-adaptive-test',
@@ -313,6 +316,7 @@ test.describe('Export progress UI', () => {
           staging_path: STAGING_DIR,
           adaptive_retries: 1,
           current_strategy: 'split_by_job',
+          current_step_seconds: 30,
           last_error_kind: 'too_many_series',
         };
       route.fulfill({
@@ -333,6 +337,55 @@ test.describe('Export progress UI', () => {
 
     await expect(page.locator('#exportAdaptiveStrategy')).toContainText('Adaptive retry: split by job');
     await page.waitForSelector('.step[data-step="7"]');
+  });
+
+  test('shows autopilot sampling step changes during export', async ({ page }) => {
+    await page.route('**/api/export/start', route => {
+      route.fulfill({
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          job_id: 'job-autopilot-step-test',
+          total_batches: 1,
+          batch_window_seconds: 60,
+          staging_path: STAGING_DIR,
+        }),
+      });
+    });
+
+    await page.route('**/api/export/status**', route => {
+      route.fulfill({
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          job_id: 'job-autopilot-step-test',
+          state: 'running',
+          total_batches: 1,
+          completed_batches: 0,
+          progress: 0.2,
+          metrics_processed: 0,
+          batch_window_seconds: 60,
+          average_batch_seconds: 0,
+          last_batch_duration_seconds: 0,
+          staging_path: STAGING_DIR,
+          adaptive_retries: 2,
+          current_strategy: 'increase_step',
+          current_step_seconds: 300,
+          last_error_kind: 'query_timeout',
+        }),
+      });
+    });
+
+    await goToObfuscationStep(page);
+    await page.waitForSelector('.step[data-step="6"].active #startExportBtn:enabled');
+    await page.evaluate(() => {
+      const btn = document.getElementById('startExportBtn');
+      if (btn && window.exportMetrics) {
+        window.exportMetrics(btn);
+      }
+    });
+
+    await expect(page.locator('#exportAdaptiveStrategy')).toContainText('Adaptive retry: lower sampling precision (5 min)');
   });
 });
 

--- a/tests/e2e/specs/export-progress.spec.js
+++ b/tests/e2e/specs/export-progress.spec.js
@@ -171,6 +171,10 @@ test.describe('Export progress UI', () => {
       const requestBody = route.request().postDataJSON();
       expect(requestBody.staging_dir).toBe(STAGING_DIR);
       expect(requestBody.metric_step_seconds).toBe(60);
+      expect(requestBody.safety).toMatchObject({
+        auto_split: true,
+        split_by_job: true,
+      });
       expect(requestBody.batching).toMatchObject({
         strategy: 'custom',
         custom_interval_seconds: 300,
@@ -251,6 +255,84 @@ test.describe('Export progress UI', () => {
     await page.waitForSelector('.step[data-step="7"]');
     await expect(page.locator('#exportProgressPercent')).toContainText('100%');
     await expect(page.locator('#exportSpoilers')).toContainText('777.777.1.1:8428');
+  });
+
+  test('shows adaptive retry state during export', async ({ page }) => {
+    await page.route('**/api/export/start', route => {
+      route.fulfill({
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          job_id: 'job-adaptive-test',
+          total_batches: 2,
+          batch_window_seconds: 60,
+          staging_path: STAGING_DIR,
+        }),
+      });
+    });
+
+    let pollCount = 0;
+    await page.route('**/api/export/status**', route => {
+      pollCount += 1;
+      const done = pollCount > 1;
+      const body = done
+        ? {
+          job_id: 'job-adaptive-test',
+          state: 'completed',
+          total_batches: 2,
+          completed_batches: 2,
+          progress: 1,
+          metrics_processed: 2000,
+          batch_window_seconds: 60,
+          average_batch_seconds: 18,
+          last_batch_duration_seconds: 16,
+          staging_path: STAGING_DIR,
+          adaptive_retries: 1,
+          current_strategy: 'split_by_job',
+          last_error_kind: 'too_many_series',
+          result: {
+            export_id: 'job-adaptive-test',
+            archive_path: '/tmp/export-adaptive.zip',
+            archive_size: 1024,
+            metrics_count: 2000,
+            sha256: 'sha256sum',
+            obfuscation_applied: true,
+            sample_data: [],
+          },
+        }
+        : {
+          job_id: 'job-adaptive-test',
+          state: 'running',
+          total_batches: 2,
+          completed_batches: 0,
+          progress: 0.1,
+          metrics_processed: 0,
+          batch_window_seconds: 60,
+          average_batch_seconds: 0,
+          last_batch_duration_seconds: 0,
+          staging_path: STAGING_DIR,
+          adaptive_retries: 1,
+          current_strategy: 'split_by_job',
+          last_error_kind: 'too_many_series',
+        };
+      route.fulfill({
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+    });
+
+    await goToObfuscationStep(page);
+    await page.waitForSelector('.step[data-step="6"].active #startExportBtn:enabled');
+    await page.evaluate(() => {
+      const btn = document.getElementById('startExportBtn');
+      if (btn && window.exportMetrics) {
+        window.exportMetrics(btn);
+      }
+    });
+
+    await expect(page.locator('#exportAdaptiveStrategy')).toContainText('Adaptive retry: split by job');
+    await page.waitForSelector('.step[data-step="7"]');
   });
 });
 


### PR DESCRIPTION
## Summary
- add adaptive export retries for VictoriaMetrics timeout and too-many-series failures
- avoid partial staging corruption by appending only fully successful attempt files
- surface retry strategy in API/UI and document the release in CHANGELOG

## Testing
- `go test ./...`
- `go test -race ./internal/application/services ./internal/infrastructure/vm ./internal/server`
- `go build -o vmgather ./cmd/vmgather`
- `cd tests/e2e && npm test -- --project=chromium --reporter=line specs/export-progress.spec.js`
