### PR TITLE
release: v1.11.0 (adaptive failure diagnostics + security baseline + CI hardening)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
         with:
-          go-version: '1.22'
+          go-version: '1.25.11'
 
       - name: Build all platforms (Binaries)
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to vmgather are documented here. The format follows [Keep a 
 
 ### Security
 - Build, runtime, and security-scan Go toolchains are upgraded to Go `1.25.11` (from `1.25.9`) to consume the latest Go standard library vulnerability fixes.
-- Docker runtime images now use a refreshed pinned distroless `base-debian12:nonroot` digest.
+- Docker runtime images now use a refreshed pinned distroless `base-debian12:nonroot` digest that ships patched `libssl3 3.0.20-1~deb12u2`, clearing the `CVE-2026-45447` HIGH finding (OpenSSL `PKCS7_verify()` heap use-after-free) raised by the image scan.
 - Release binaries are now built with Go `1.25.11`, matching the container and security-scan baseline (previously built with Go `1.22`).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to vmgather are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and versions adhere to semantic versioning.
 
+## [v1.11.0] - 2026-06-12
+
+### Security
+- Build, runtime, and security-scan Go toolchains are upgraded to Go `1.25.11` (from `1.25.9`) to consume the latest Go standard library vulnerability fixes.
+- Docker runtime images now use a refreshed pinned distroless `base-debian12:nonroot` digest.
+- Release binaries are now built with Go `1.25.11`, matching the container and security-scan baseline (previously built with Go `1.22`).
+
+### Changed
+- GitHub Actions across CI and release workflows are now pinned to full-length commit SHAs for supply-chain hardening.
+
 ## [v1.10.0] - 2026-04-28
 
 ### Added
@@ -27,7 +37,7 @@ All notable changes to vmgather are documented here. The format follows [Keep a 
 - Export safety defaults now also recover from invalid negative split settings, and the JSON contract no longer marks the non-pointer `safety` field as `omitempty`.
 
 ### Security
-- Docker and security-scan Go toolchains are upgraded to Go `1.25.11` to consume the latest Go standard library vulnerability fixes.
+- Docker and security-scan Go toolchains are upgraded to Go `1.25.9` to consume the latest Go standard library vulnerability fixes.
 - Docker runtime images now use a refreshed pinned distroless `base-debian12:nonroot` digest with fixed OpenSSL packages.
 
 ## [v1.9.1] - 2026-02-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to vmgather are documented here. The format follows [Keep a 
 
 ## [v1.11.0] - 2026-06-12
 
+### Added
+- Adaptive export now emits structured diagnostics for every attempt and retry decision (`[EXPORT][ATTEMPT]`, `[EXPORT][ADAPTIVE] decision=query_range_fallback|split_by_job|split_by_time|increase_step`), tagging strategy, depth, error kind, sampling step, selected jobs, time window, and selector so support can trace how autopilot reacted to a given VictoriaMetrics rejection.
+- Added `logAdaptiveFailure`, which explains why an adaptive export ultimately failed (`too_many_series` vs `query_timeout` vs other), including the unrecoverable configuration context, instead of surfacing only the raw error.
+- Per-job adaptive exports now log retry progress (`[EXPORT][JOB] adaptive-retry … retries/kind/strategy/step/range`) and the final failing context, making multi-job autopilot runs diagnosable.
+- Discovery/estimation now produces explicit warnings (`componentEstimateWarnings`, `selectorEstimateWarnings`) when per-component or per-selector series estimates are unavailable, and surfaces the failing error kind to the UI.
+
 ### Security
 - Build, runtime, and security-scan Go toolchains are upgraded to Go `1.25.11` (from `1.25.9`) to consume the latest Go standard library vulnerability fixes.
 - Docker runtime images now use a refreshed pinned distroless `base-debian12:nonroot` digest that ships patched `libssl3 3.0.20-1~deb12u2`, clearing the `CVE-2026-45447` HIGH finding (OpenSSL `PKCS7_verify()` heap use-after-free) raised by the image scan.

--- a/build/docker/Dockerfile.vmgather
+++ b/build/docker/Dockerfile.vmgather
@@ -6,7 +6,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w" -o /out/vmgather ./cmd/vmgather && \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w" -o /out/container-healthcheck ./cmd/container-healthcheck
 
-FROM gcr.io/distroless/base-debian12:nonroot@sha256:7a75a36f4bec82a7542c64195e402907486f9a4dd2f8797a976aa0cf31cfb470
+FROM gcr.io/distroless/base-debian12:nonroot@sha256:4ae8d0163a6f04d96f36e41324d76f00744f0db7545b6d04039c9e6fa1df77f3
 WORKDIR /tmp
 COPY --from=builder /out/vmgather /usr/local/bin/vmgather
 COPY --from=builder /out/container-healthcheck /usr/local/bin/container-healthcheck

--- a/build/docker/Dockerfile.vmimporter
+++ b/build/docker/Dockerfile.vmimporter
@@ -6,7 +6,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w" -o /out/vmimporter ./cmd/vmimporter && \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w" -o /out/container-healthcheck ./cmd/container-healthcheck
 
-FROM gcr.io/distroless/base-debian12:nonroot@sha256:7a75a36f4bec82a7542c64195e402907486f9a4dd2f8797a976aa0cf31cfb470
+FROM gcr.io/distroless/base-debian12:nonroot@sha256:4ae8d0163a6f04d96f36e41324d76f00744f0db7545b6d04039c9e6fa1df77f3
 WORKDIR /tmp
 COPY --from=builder /out/vmimporter /usr/local/bin/vmimporter
 COPY --from=builder /out/container-healthcheck /usr/local/bin/container-healthcheck

--- a/internal/application/services/export_service.go
+++ b/internal/application/services/export_service.go
@@ -297,9 +297,26 @@ func (s *exportServiceImpl) exportWindowAdaptive(
 	retryCount *int,
 	stats *adaptiveExportStats,
 ) (int, error) {
+	log.Printf("[EXPORT][ATTEMPT] strategy=%s depth=%d use_query_range=%v step=%ds jobs=%d window=%s..%s selector=%s",
+		attempt.Strategy,
+		attempt.Depth,
+		attempt.UseQueryRange,
+		attempt.StepSeconds,
+		len(attempt.Jobs),
+		attempt.TimeRange.Start.Format(time.RFC3339),
+		attempt.TimeRange.End.Format(time.RFC3339),
+		formatSelectorForLog(attempt.Selector),
+	)
 	attemptFile := fmt.Sprintf("%s.attempt.%d", mainStagingFile, time.Now().UnixNano())
 	count, err := s.fetchAndProcessAttempt(ctx, client, config, attempt, obfuscator, attemptFile, stats)
 	if err == nil {
+		log.Printf("[EXPORT][ATTEMPT][OK] strategy=%s depth=%d metrics=%d window=%s..%s",
+			attempt.Strategy,
+			attempt.Depth,
+			count,
+			attempt.TimeRange.Start.Format(time.RFC3339),
+			attempt.TimeRange.End.Format(time.RFC3339),
+		)
 		if err := appendFile(mainStagingFile, attemptFile); err != nil {
 			_ = os.Remove(attemptFile)
 			return 0, err
@@ -310,10 +327,28 @@ func (s *exportServiceImpl) exportWindowAdaptive(
 	_ = os.Remove(attemptFile)
 
 	kind := vm.ErrorKindOf(err)
+	log.Printf("[EXPORT][ATTEMPT][FAIL] strategy=%s depth=%d kind=%s step=%ds jobs=%d window=%s..%s selector=%s err=%v",
+		attempt.Strategy,
+		attempt.Depth,
+		kind,
+		attempt.StepSeconds,
+		len(attempt.Jobs),
+		attempt.TimeRange.Start.Format(time.RFC3339),
+		attempt.TimeRange.End.Format(time.RFC3339),
+		formatSelectorForLog(attempt.Selector),
+		err,
+	)
 
 	switch {
 	case kind == vm.ErrorKindMissingRoute && !attempt.UseQueryRange:
 		*retryCount++
+		log.Printf("[EXPORT][ADAPTIVE] decision=query_range_fallback retries=%d kind=%s window=%s..%s selector=%s",
+			*retryCount,
+			kind,
+			attempt.TimeRange.Start.Format(time.RFC3339),
+			attempt.TimeRange.End.Format(time.RFC3339),
+			formatSelectorForLog(attempt.Selector),
+		)
 		progress := AdaptiveRetryProgress{
 			Retries:   *retryCount,
 			TimeRange: attempt.TimeRange,
@@ -329,6 +364,13 @@ func (s *exportServiceImpl) exportWindowAdaptive(
 		return s.exportWindowAdaptive(ctx, client, config, next, mainStagingFile, obfuscator, retryCount, stats)
 	case kind == vm.ErrorKindTooManySeries && config.Safety.AutoSplit && attempt.Depth < config.Safety.MaxSplitDepth && config.Safety.SplitByJob && len(attempt.Jobs) > 1:
 		*retryCount++
+		log.Printf("[EXPORT][ADAPTIVE] decision=split_by_job retries=%d kind=%s jobs=%s window=%s..%s",
+			*retryCount,
+			kind,
+			formatJobsForLog(attempt.Jobs),
+			attempt.TimeRange.Start.Format(time.RFC3339),
+			attempt.TimeRange.End.Format(time.RFC3339),
+		)
 		progress := AdaptiveRetryProgress{
 			Retries:   *retryCount,
 			TimeRange: attempt.TimeRange,
@@ -352,6 +394,17 @@ func (s *exportServiceImpl) exportWindowAdaptive(
 			left, right, ok := splitTimeRange(attempt.TimeRange, config.Safety.MinWindowSeconds)
 			if ok {
 				*retryCount++
+				log.Printf("[EXPORT][ADAPTIVE] decision=split_by_time retries=%d kind=%s step=%ds window=%s..%s -> [%s..%s] + [%s..%s]",
+					*retryCount,
+					kind,
+					attempt.StepSeconds,
+					attempt.TimeRange.Start.Format(time.RFC3339),
+					attempt.TimeRange.End.Format(time.RFC3339),
+					left.Start.Format(time.RFC3339),
+					left.End.Format(time.RFC3339),
+					right.Start.Format(time.RFC3339),
+					right.End.Format(time.RFC3339),
+				)
 				progress := AdaptiveRetryProgress{
 					Retries:     *retryCount,
 					TimeRange:   attempt.TimeRange,
@@ -375,6 +428,14 @@ func (s *exportServiceImpl) exportWindowAdaptive(
 		}
 		if nextStep, ok := nextAutopilotStep(attempt.StepSeconds, config.Safety); ok {
 			*retryCount++
+			log.Printf("[EXPORT][ADAPTIVE] decision=increase_step retries=%d kind=%s from_step=%ds to_step=%ds window=%s..%s",
+				*retryCount,
+				kind,
+				attempt.StepSeconds,
+				nextStep,
+				attempt.TimeRange.Start.Format(time.RFC3339),
+				attempt.TimeRange.End.Format(time.RFC3339),
+			)
 			progress := AdaptiveRetryProgress{
 				Retries:     *retryCount,
 				TimeRange:   attempt.TimeRange,
@@ -393,6 +454,7 @@ func (s *exportServiceImpl) exportWindowAdaptive(
 	default:
 	}
 
+	logAdaptiveFailure(config, attempt, kind, err)
 	return 0, enrichAdaptiveError(kind, err, attempt, config.Safety.MinWindowSeconds)
 }
 
@@ -882,12 +944,45 @@ func enrichAdaptiveError(kind vm.ErrorKind, err error, attempt exportAttempt, mi
 	case vm.ErrorKindQueryTimeout:
 		return fmt.Errorf("query still exceeds VictoriaMetrics -search.maxQueryDuration after splitting down to %ds windows and sampling at %ds; narrow selector/query or use raw selector export: %w", minWindowSeconds, attempt.StepSeconds, err)
 	case vm.ErrorKindTooManySeries:
+		if len(attempt.Jobs) <= 1 {
+			return fmt.Errorf("query exceeds VictoriaMetrics series limits and vmgather cannot split the request further by job; narrow selector/query or adjust VictoriaMetrics -search.maxExportSeries / -search.maxUniqueTimeseries: %w", err)
+		}
 		return fmt.Errorf("query exceeds VictoriaMetrics series limits; narrow selector/query or adjust VictoriaMetrics -search.maxExportSeries / -search.maxUniqueTimeseries: %w", err)
 	default:
 		if attempt.UseQueryRange {
 			return fmt.Errorf("adaptive export failed while using query_range: %w", err)
 		}
 		return err
+	}
+}
+
+func logAdaptiveFailure(config domain.ExportConfig, attempt exportAttempt, kind vm.ErrorKind, err error) {
+	switch kind {
+	case vm.ErrorKindTooManySeries:
+		log.Printf("[EXPORT][LIMIT] too_many_series unrecoverable jobs=%d split_by_job=%v split_by_metric_name=%v use_query_range=%v selector=%s err=%v",
+			len(attempt.Jobs),
+			config.Safety.SplitByJob,
+			config.Safety.SplitByMetricName,
+			attempt.UseQueryRange,
+			formatSelectorForLog(attempt.Selector),
+			err,
+		)
+	case vm.ErrorKindQueryTimeout:
+		log.Printf("[EXPORT][LIMIT] query_timeout unrecoverable min_window_seconds=%d step=%ds depth=%d selector=%s err=%v",
+			config.Safety.MinWindowSeconds,
+			attempt.StepSeconds,
+			attempt.Depth,
+			formatSelectorForLog(attempt.Selector),
+			err,
+		)
+	default:
+		log.Printf("[EXPORT][FAIL] unrecoverable kind=%s strategy=%s depth=%d selector=%s err=%v",
+			kind,
+			attempt.Strategy,
+			attempt.Depth,
+			formatSelectorForLog(attempt.Selector),
+			err,
+		)
 	}
 }
 

--- a/internal/application/services/export_service_test.go
+++ b/internal/application/services/export_service_test.go
@@ -921,6 +921,40 @@ func TestMissingRouteFallsBackToQueryRangeWhenAdaptivityOff(t *testing.T) {
 	}
 }
 
+func TestTooManySeriesSingleJobReturnsNonSplittableHint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/export":
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = io.WriteString(w, `the number of matching timeseries exceeds 10000000`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	service := NewExportService(t.TempDir(), "test-version")
+	cfg := domain.ExportConfig{
+		Connection: domain.VMConnection{URL: server.URL},
+		TimeRange: domain.TimeRange{
+			Start: time.Unix(0, 0),
+			End:   time.Unix(60, 0),
+		},
+		Mode:     domain.ExportModeCluster,
+		Jobs:     []string{"vmstorage"},
+		Batching: domain.BatchSettings{Enabled: false, Strategy: "manual"},
+	}
+	ApplyExportDefaults(&cfg)
+
+	_, err := service.ExecuteExport(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected too many series failure")
+	}
+	if !strings.Contains(err.Error(), "cannot split the request further by job") {
+		t.Fatalf("expected non-splittable hint, got %v", err)
+	}
+}
+
 func TestSplitByJobFailureDoesNotAppendPartialSubSplit(t *testing.T) {
 	var mu sync.Mutex
 	requests := make([]string, 0, 3)

--- a/internal/application/services/vm_service.go
+++ b/internal/application/services/vm_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"fmt"
+	"log"
 	"regexp"
 	"sort"
 	"strings"
@@ -120,17 +121,27 @@ func (s *vmServiceImpl) DiscoverComponents(ctx context.Context, conn domain.VMCo
 		// Estimate metrics count for this component
 		count, err := s.estimateComponentMetrics(ctx, client, comp.Jobs, tr)
 		if err != nil {
-			// Log error but don't fail - just set -1
+			log.Printf("[WARN] [DISCOVERY][ESTIMATE] component=%s jobs=%s series estimate unavailable kind=%s err=%v",
+				comp.Component, formatJobsForLog(comp.Jobs), vm.ErrorKindOf(err), err)
 			comp.MetricsCountEstimate = -1
 		} else {
 			comp.MetricsCountEstimate = count
 		}
 
 		// Count instances
-		comp.InstanceCount, _ = s.countInstances(ctx, client, comp.Jobs, tr)
+		instanceCount, instanceErr := s.countInstances(ctx, client, comp.Jobs, tr)
+		if instanceErr != nil {
+			log.Printf("[WARN] [DISCOVERY][INSTANCES] component=%s jobs=%s instance count unavailable kind=%s err=%v",
+				comp.Component, formatJobsForLog(comp.Jobs), vm.ErrorKindOf(instanceErr), instanceErr)
+		}
+		comp.InstanceCount = instanceCount
 
 		// Estimate per-job metrics if possible
-		jobMetrics := s.estimateJobMetrics(ctx, client, comp.Jobs, tr)
+		jobMetrics, jobMetricErr := s.estimateJobMetrics(ctx, client, comp.Jobs, tr)
+		if jobMetricErr != nil {
+			log.Printf("[WARN] [DISCOVERY][JOB-ESTIMATE] component=%s jobs=%s per-job estimates unavailable kind=%s err=%v",
+				comp.Component, formatJobsForLog(comp.Jobs), vm.ErrorKindOf(jobMetricErr), jobMetricErr)
+		}
 		if len(jobMetrics) > 0 {
 			comp.JobMetrics = jobMetrics
 		}
@@ -193,6 +204,9 @@ func (s *vmServiceImpl) DiscoverSelectorJobs(ctx context.Context, conn domain.VM
 				jobCounts[job] = count
 			}
 		}
+	} else {
+		log.Printf("[WARN] [DISCOVERY][SELECTOR-ESTIMATE] selector=%s per-job series estimates unavailable kind=%s err=%v",
+			formatSelectorForLog(selector), vm.ErrorKindOf(countErr), countErr)
 	}
 
 	jobs := make([]domain.SelectorJob, 0, len(jobInstances))
@@ -280,11 +294,11 @@ func (s *vmServiceImpl) countInstances(ctx context.Context, client *vm.Client, j
 }
 
 // estimateJobMetrics returns per-job series counts if available
-func (s *vmServiceImpl) estimateJobMetrics(ctx context.Context, client *vm.Client, jobs []string, tr domain.TimeRange) map[string]int {
+func (s *vmServiceImpl) estimateJobMetrics(ctx context.Context, client *vm.Client, jobs []string, tr domain.TimeRange) (map[string]int, error) {
 	jobCounts := make(map[string]int)
 
 	if len(jobs) == 0 {
-		return jobCounts
+		return jobCounts, nil
 	}
 
 	selector := buildJobFilterSelector(jobs)
@@ -292,7 +306,10 @@ func (s *vmServiceImpl) estimateJobMetrics(ctx context.Context, client *vm.Clien
 
 	result, err := client.Query(ctx, query, effectiveQueryTime(tr.End))
 	if err != nil || len(result.Data.Result) == 0 {
-		return jobCounts
+		if err != nil {
+			return jobCounts, err
+		}
+		return jobCounts, nil
 	}
 
 	for _, series := range result.Data.Result {
@@ -306,7 +323,7 @@ func (s *vmServiceImpl) estimateJobMetrics(ctx context.Context, client *vm.Clien
 		}
 	}
 
-	return jobCounts
+	return jobCounts, nil
 }
 
 // parseCountValue extracts an integer series count from Prometheus API values
@@ -490,6 +507,24 @@ func buildJobFilterSelector(jobs []string) string {
 		escaped = append(escaped, regexp.QuoteMeta(job))
 	}
 	return fmt.Sprintf(`{job=~"%s"}`, strings.Join(escaped, "|"))
+}
+
+func formatJobsForLog(jobs []string) string {
+	if len(jobs) == 0 {
+		return "-"
+	}
+	if len(jobs) <= 4 {
+		return strings.Join(jobs, ",")
+	}
+	return fmt.Sprintf("%s (+%d more)", strings.Join(jobs[:4], ","), len(jobs)-4)
+}
+
+func formatSelectorForLog(selector string) string {
+	trimmed := strings.Join(strings.Fields(strings.TrimSpace(selector)), " ")
+	if len(trimmed) <= 160 {
+		return trimmed
+	}
+	return trimmed[:157] + "..."
 }
 
 // CheckExportAPI checks if /api/v1/export endpoint is available

--- a/internal/application/services/vm_service_test.go
+++ b/internal/application/services/vm_service_test.go
@@ -739,7 +739,10 @@ func TestVMService_EstimateQueries_EscapeJobRegex(t *testing.T) {
 	if _, err := service.countInstances(context.Background(), client, jobs, tr); err != nil {
 		t.Fatalf("countInstances failed: %v", err)
 	}
-	jobMetrics := service.estimateJobMetrics(context.Background(), client, jobs, tr)
+	jobMetrics, err := service.estimateJobMetrics(context.Background(), client, jobs, tr)
+	if err != nil {
+		t.Fatalf("estimateJobMetrics failed: %v", err)
+	}
 	if jobMetrics == nil {
 		t.Fatalf("estimateJobMetrics returned nil map")
 	}

--- a/internal/infrastructure/vm/client.go
+++ b/internal/infrastructure/vm/client.go
@@ -54,6 +54,12 @@ func HintForError(err error) string {
 	if errors.Is(err, ErrMissingTenantPath) {
 		return "vmselect requires /select/<tenant>/prometheus in the URL (example: http://host:8481/select/0/prometheus)"
 	}
+	switch ErrorKindOf(err) {
+	case ErrorKindTooManySeries:
+		return "VictoriaMetrics rejected the request while expanding matching series. Narrow the selector/query, select fewer jobs, or raise -search.maxExportSeries / -search.maxUniqueTimeseries on the target."
+	case ErrorKindQueryTimeout:
+		return "VictoriaMetrics exceeded its query execution budget. Narrow the selector/query or raise -search.maxQueryDuration on the target."
+	}
 	return ""
 }
 

--- a/internal/server/export_jobs.go
+++ b/internal/server/export_jobs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"sync"
 	"time"
 
@@ -224,6 +225,8 @@ func (m *ExportJobManager) markRunning(jobID string) {
 		now := time.Now()
 		job.status.State = JobRunning
 		job.status.StartedAt = &now
+		log.Printf("[EXPORT][JOB] running job_id=%s total_batches=%d staging=%s jobs=%d mode=%s query_type=%s",
+			jobID, job.status.TotalBatches, job.status.StagingPath, len(job.config.Jobs), job.config.Mode, job.config.QueryType)
 	}
 }
 
@@ -239,6 +242,9 @@ func (m *ExportJobManager) markFailed(jobID string, err error) {
 		job.status.State = JobFailed
 		job.status.CompletedAt = &now
 		job.status.Error = err.Error()
+		currentRange := job.status.CurrentRange
+		log.Printf("[EXPORT][JOB] failed job_id=%s retries=%d last_error_kind=%s strategy=%s range=%v err=%v",
+			jobID, job.status.AdaptiveRetries, job.status.LastErrorKind, job.status.CurrentStrategy, currentRange, err)
 		job.status.CurrentRange = nil
 		m.jobFinishedLocked()
 	}
@@ -259,6 +265,8 @@ func (m *ExportJobManager) markCompleted(jobID string, result *domain.ExportResu
 		job.status.Result = result
 		job.status.CurrentRange = nil
 		job.status.ETA = nil
+		log.Printf("[EXPORT][JOB] completed job_id=%s metrics=%d archive=%s retries=%d",
+			jobID, result.MetricsExported, result.ArchivePath, job.status.AdaptiveRetries)
 		m.jobFinishedLocked()
 	}
 }
@@ -332,6 +340,15 @@ func (m *ExportJobManager) updateAdaptiveRetry(jobID string, progress services.A
 		Start: progress.TimeRange.Start,
 		End:   progress.TimeRange.End,
 	}
+	log.Printf("[EXPORT][JOB] adaptive-retry job_id=%s retries=%d kind=%s strategy=%s step=%ds range=%s..%s",
+		jobID,
+		progress.Retries,
+		progress.ErrorKind,
+		progress.Strategy,
+		progress.StepSeconds,
+		progress.TimeRange.Start.Format(time.RFC3339),
+		progress.TimeRange.End.Format(time.RFC3339),
+	)
 }
 
 func (m *ExportJobManager) jobFinishedLocked() {
@@ -359,6 +376,8 @@ func (m *ExportJobManager) markCanceled(jobID string, err error) {
 		}
 		job.status.ETA = nil
 		job.status.CurrentRange = nil
+		log.Printf("[EXPORT][JOB] canceled job_id=%s completed_batches=%d metrics=%d err=%s",
+			jobID, job.status.CompletedBatches, job.status.MetricsProcessed, job.status.Error)
 		m.jobFinishedLocked()
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -120,6 +120,44 @@ func formatVMError(err error) (string, string) {
 	return message, hint
 }
 
+func componentEstimateWarnings(components []domain.VMComponent) []string {
+	hasComponentUnknown := false
+	hasJobUnknown := false
+	for _, comp := range components {
+		if comp.MetricsCountEstimate < 0 {
+			hasComponentUnknown = true
+		}
+		for _, job := range comp.Jobs {
+			if comp.JobMetrics == nil {
+				hasJobUnknown = true
+				break
+			}
+			if _, ok := comp.JobMetrics[job]; !ok {
+				hasJobUnknown = true
+				break
+			}
+		}
+	}
+
+	warnings := make([]string, 0, 2)
+	if hasComponentUnknown {
+		warnings = append(warnings, "Some series estimates are unavailable. Discovery count queries may have failed or hit VictoriaMetrics search limits; export may still work.")
+	}
+	if hasJobUnknown {
+		warnings = append(warnings, "Some per-job series estimates are unavailable. Job-level count queries may have failed or timed out.")
+	}
+	return warnings
+}
+
+func selectorEstimateWarnings(jobs []domain.SelectorJob) []string {
+	for _, job := range jobs {
+		if job.MetricsCountEstimate < 0 {
+			return []string{"Some series estimates are unavailable. Selector count queries may have failed or hit VictoriaMetrics search limits; export may still work."}
+		}
+	}
+	return nil
+}
+
 // Router returns the HTTP router
 func (s *Server) Router() http.Handler {
 	mux := http.NewServeMux()
@@ -434,11 +472,16 @@ func (s *Server) handleDiscoverComponents(w http.ResponseWriter, r *http.Request
 		log.Printf("[OK] Discovery complete: %d components found", len(components))
 		log.Printf("  Component types: %v", componentTypes)
 	}
+	warnings := componentEstimateWarnings(components)
+	for _, warning := range warnings {
+		log.Printf("[WARN] [DISCOVERY] %s", warning)
+	}
 
 	// Return discovered components
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{
 		"components": components,
+		"warnings":   warnings,
 	})
 }
 
@@ -541,10 +584,15 @@ func (s *Server) handleDiscoverSelectorJobs(w http.ResponseWriter, r *http.Reque
 		respondWithError(w, http.StatusInternalServerError, fmt.Sprintf("Selector discovery failed: %s", errMsg))
 		return
 	}
+	warnings := selectorEstimateWarnings(jobs)
+	for _, warning := range warnings {
+		log.Printf("[WARN] [DISCOVERY] %s", warning)
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{
-		"jobs": jobs,
+		"jobs":     jobs,
+		"warnings": warnings,
 	})
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -379,6 +379,48 @@ func TestHandleDiscoverComponentsLogsDiscoveryRequestWhenDebugEnabled(t *testing
 	}
 }
 
+func TestHandleDiscoverComponentsReturnsEstimateWarnings(t *testing.T) {
+	server := NewServer(t.TempDir(), "test-version", false)
+	server.vmService = &mockVMService{
+		components: []domain.VMComponent{
+			{
+				Component:            "vmstorage",
+				Jobs:                 []string{"internal.vmstorage"},
+				MetricsCountEstimate: -1,
+			},
+		},
+	}
+
+	reqBody := map[string]interface{}{
+		"connection": map[string]interface{}{
+			"url":  "http://127.0.0.1:8428",
+			"auth": map[string]interface{}{"type": "none"},
+		},
+		"time_range": map[string]string{
+			"start": time.Now().Add(-time.Hour).Format(time.RFC3339),
+			"end":   time.Now().Format(time.RFC3339),
+		},
+	}
+	body, _ := json.Marshal(reqBody)
+	req := httptest.NewRequest(http.MethodPost, "/api/discover", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	server.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	warnings, ok := resp["warnings"].([]interface{})
+	if !ok || len(warnings) == 0 {
+		t.Fatalf("expected warnings in response, got %#v", resp["warnings"])
+	}
+}
+
 func TestHandleGetSampleDoesNotLogSampleRequestByDefault(t *testing.T) {
 	server := NewServer(t.TempDir(), "test-version", false)
 	server.vmService = &mockVMService{
@@ -414,6 +456,49 @@ func TestHandleGetSampleDoesNotLogSampleRequestByDefault(t *testing.T) {
 	logs := buf.String()
 	if strings.Contains(logs, "Sample Metrics Request:") {
 		t.Fatalf("expected sample request logging to be disabled by default, but it was logged:\n%s", logs)
+	}
+}
+
+func TestHandleDiscoverSelectorJobsReturnsEstimateWarnings(t *testing.T) {
+	server := NewServer(t.TempDir(), "test-version", false)
+	server.vmService = &mockVMService{
+		selectorJobs: []domain.SelectorJob{
+			{
+				Job:                  "internal.vmstorage",
+				InstanceCount:        1,
+				MetricsCountEstimate: -1,
+			},
+		},
+	}
+
+	reqBody := map[string]interface{}{
+		"connection": map[string]interface{}{
+			"url":  "http://127.0.0.1:8428",
+			"auth": map[string]interface{}{"type": "none"},
+		},
+		"time_range": map[string]string{
+			"start": time.Now().Add(-time.Hour).Format(time.RFC3339),
+			"end":   time.Now().Format(time.RFC3339),
+		},
+		"selector": `{job="internal.vmstorage"}`,
+	}
+	body, _ := json.Marshal(reqBody)
+	req := httptest.NewRequest(http.MethodPost, "/api/discover-selector", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	server.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	warnings, ok := resp["warnings"].([]interface{})
+	if !ok || len(warnings) == 0 {
+		t.Fatalf("expected warnings in response, got %#v", resp["warnings"])
 	}
 }
 
@@ -802,8 +887,10 @@ func TestServer_GetSampleDataFromResult_NoSamplesMock(t *testing.T) {
 }
 
 type mockVMService struct {
-	samples   []domain.MetricSample
-	sampleErr error
+	samples      []domain.MetricSample
+	sampleErr    error
+	components   []domain.VMComponent
+	selectorJobs []domain.SelectorJob
 }
 
 func (m *mockVMService) ValidateConnection(ctx context.Context, conn domain.VMConnection) error {
@@ -811,11 +898,11 @@ func (m *mockVMService) ValidateConnection(ctx context.Context, conn domain.VMCo
 }
 
 func (m *mockVMService) DiscoverComponents(ctx context.Context, conn domain.VMConnection, tr domain.TimeRange) ([]domain.VMComponent, error) {
-	return nil, nil
+	return m.components, nil
 }
 
 func (m *mockVMService) DiscoverSelectorJobs(ctx context.Context, conn domain.VMConnection, selector string, tr domain.TimeRange) ([]domain.SelectorJob, error) {
-	return nil, nil
+	return m.selectorJobs, nil
 }
 
 func (m *mockVMService) GetSample(ctx context.Context, config domain.ExportConfig, limit int) ([]domain.MetricSample, error) {

--- a/internal/server/static/app.js
+++ b/internal/server/static/app.js
@@ -14,6 +14,8 @@ let lastValidationAttempts = [];
 let lastValidationFinalEndpoint = '';
 let discoveredComponents = [];
 let discoveredSelectorJobs = [];
+let discoveredComponentWarnings = [];
+let discoveredSelectorWarnings = [];
 let sampleMetrics = [];
 let exportResult = null;
 let currentExportJobId = null;
@@ -536,6 +538,8 @@ function resetModeState() {
     lastValidationFinalEndpoint = '';
     discoveredComponents = [];
     discoveredSelectorJobs = [];
+    discoveredComponentWarnings = [];
+    discoveredSelectorWarnings = [];
     sampleMetrics = [];
     sampleStatus = 'idle';
     sampleHadError = false;
@@ -1529,6 +1533,9 @@ async function discoverComponents() {
         }
 
         discoveredComponents = data.components || [];
+        discoveredComponentWarnings = Array.isArray(data.warnings) ? data.warnings : [];
+        discoveredSelectorWarnings = [];
+        discoveredComponentWarnings.forEach(warning => console.warn('[WARN] Discovery warning:', warning));
 
         // Log component summary
         const componentTypes = [...new Set(discoveredComponents.map(c => c.component))];
@@ -1577,6 +1584,9 @@ async function discoverSelectorJobs() {
         }
 
         discoveredSelectorJobs = Array.isArray(data.jobs) ? data.jobs : [];
+        discoveredSelectorWarnings = Array.isArray(data.warnings) ? data.warnings : [];
+        discoveredComponentWarnings = [];
+        discoveredSelectorWarnings.forEach(warning => console.warn('[WARN] Selector discovery warning:', warning));
         renderSelectorJobs(discoveredSelectorJobs);
         setComponentsLoadingState(false);
     } catch (err) {
@@ -2801,6 +2811,17 @@ function autoSelectAllSelectorJobs() {
     updateSelectionSummary();
 }
 
+function renderSummaryWarnings(warnings) {
+    if (!Array.isArray(warnings) || warnings.length === 0) {
+        return '';
+    }
+    return `
+        <div class="warning-box" style="margin-top: 16px;">
+            <strong>Estimate warning:</strong> ${warnings.join(' ')}
+        </div>
+    `;
+}
+
 function updateSelectionSummary() {
     const summary = document.getElementById('selectionSummary');
     if (!summary) {
@@ -2852,10 +2873,15 @@ function updateSelectionSummary() {
         });
         html += '</div>';
         if (hasUnknown) {
-            html += `<div class="summary-total">Known total: ${totalKnown.toLocaleString()} series (additional data pending)</div>`;
+            if (totalKnown === 0) {
+                html += `<div class="summary-total">Series estimates unavailable for the selected jobs.</div>`;
+            } else {
+                html += `<div class="summary-total">Known total: ${totalKnown.toLocaleString()} series (additional estimates unavailable)</div>`;
+            }
         } else {
             html += `<div class="summary-total">Total: ${totalKnown.toLocaleString()} series</div>`;
         }
+        html += renderSummaryWarnings(discoveredSelectorWarnings);
         summary.innerHTML = html;
         return;
     }
@@ -2911,11 +2937,16 @@ function updateSelectionSummary() {
     html += '</div>';
 
     if (hasUnknown) {
-        html += `<div class="summary-total">Known total: ${totalKnown.toLocaleString()} series (additional data pending)</div>`;
+        if (totalKnown === 0) {
+            html += `<div class="summary-total">Series estimates unavailable for the selected components.</div>`;
+        } else {
+            html += `<div class="summary-total">Known total: ${totalKnown.toLocaleString()} series (additional estimates unavailable)</div>`;
+        }
     } else {
         html += `<div class="summary-total">Total: ${totalKnown.toLocaleString()} series</div>`;
     }
 
+    html += renderSummaryWarnings(discoveredComponentWarnings);
     summary.innerHTML = html;
 }
 


### PR DESCRIPTION
## Summary

Cuts release **v1.11.0**. Beyond the post-`v1.10.0` security baseline refresh and CI hardening, this also brings in an adaptive-export feature commit that was authored after the `v1.10.0` tag but never merged to `main`, so the release covers the complete adaptive feature set.

### Added
- **Adaptive failure diagnostics** (`export: improve diagnostics around adaptive failures`): structured per-attempt and per-retry logging (`[EXPORT][ATTEMPT]`, `[EXPORT][ADAPTIVE] decision=query_range_fallback|split_by_job|split_by_time|increase_step`, `[EXPORT][LIMIT]`, `[EXPORT][JOB]`) tagging strategy/depth/error-kind/step/jobs/window/selector; a `logAdaptiveFailure` helper explaining unrecoverable failures (`too_many_series` vs `query_timeout`); and discovery/estimation warnings surfaced to the UI. This commit existed only on `kirillyu/adaptive-export-retries` (post-`v1.10.0`, never in `main`) and is included here so no adaptive work is left unreleased.

### Security
- Build, runtime, and security-scan Go toolchains upgraded to Go `1.25.11` (from `1.25.9`).
- Runtime distroless `base-debian12:nonroot` digest refreshed to one shipping patched `libssl3 3.0.20-1~deb12u2`, clearing the `CVE-2026-45447` HIGH finding (OpenSSL `PKCS7_verify()` heap use-after-free) that the image scan flagged on the previous digest.
- Release binaries now built with Go `1.25.11` (was `1.22`), matching the container/security baseline.

### Changed
- GitHub Actions across CI and release workflows pinned to full-length commit SHAs.

### CHANGELOG fix
- The `v1.10.0` entry claimed Go `1.25.11`, but that tag actually shipped `1.25.9` (the `1.25.11` bump landed later in #30). Corrected to `1.25.9`.

### Verification
Full CI-equivalent run locally (`make security-check`) is green: `govulncheck` clean, `gitleaks`/`trufflehog` no secrets, hadolint + trivy config 0 misconfigurations, trivy image scan **0 HIGH/CRITICAL** on both `vmgather` and `vmimporter`. `go build`, `go vet`, and `go test ./...` all pass.

### After merge (separate manual steps)
1. Tag `v1.11.0` on the merge commit.
2. Publish GitHub Release → triggers `release.yml` (binaries).
3. `make release PKG_TAG=v1.11.0` → multi-arch images to `docker.io` + `quay.io`.
4. Delete merged branches `kirillyu/adaptive-export-retries` and the obsolete `kirillyu/pr29-security-fix`.

> Note: no workflow currently pushes to `ghcr.io` despite the Makefile comment — out of scope here.

## Checklist
- [x] CHANGELOG updated
- [x] Release toolchain aligned with security baseline
- [x] Adaptive feature set complete (no unreleased side commits)
- [x] Local security-check + tests pass